### PR TITLE
feat(core): add middleware support to core functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ yarn add @aura-stack/router
 ```ts
 import { createEndpoint, createRouter } from "@aura-stack/router";
 
-const session = createEndpoint("GET", "/auth/session", async (_req, ctx) => {
+const session = createEndpoint("GET", "/auth/session", async (_, ctx) => {
   return Response.json(
     {
       session: {
@@ -82,10 +82,12 @@ export const signIn = createEndpoint(
 **Validation.** Provide Zod schemas in `createEndpointConfig`:
 
 ```ts
+import { createEndpoint, createEndpointConfig } from "@aura-stack/router";
+
 const config = createEndpointConfig({
   schemas: {
     searchParams: z.object({
-      redirect_uri: z.string().url(),
+      redirect_uri: z.string(),
     }),
   },
 });
@@ -104,12 +106,14 @@ const oauth = createEndpoint(
 
 If validation fails, the helper throws an informative error before your handler executes.
 
-**Middlewares.** Supply async middleware functions that can read/augment the context:
+**Middlewares.** Provide async middleware functions to read or modify the request.
 
 ```ts
-const audit: MiddlewareFunction = async (request, ctx) => {
-  ctx.headers.set("x-request-id", crypto.randomUUID());
-  return ctx;
+import { createRouter, type GlobalMiddleware } from "@aura-stack/router";
+
+const audit: GlobalMiddleware = async (request) => {
+  request.headers.set("x-request-id", crypto.randomUUID());
+  return request;
 };
 
 const router = createRouter([oauth], { middlewares: [audit] });

--- a/src/context.ts
+++ b/src/context.ts
@@ -166,5 +166,9 @@ export const getBody = async <Config extends EndpointConfig>(
   ) {
     return await request.blob();
   }
-  throw new Error(`Unsupported Content-Type: ${contentType}`);
+  /**
+   * @todo: Handle other content types
+   * throw new Error(`Unsupported Content-Type: ${contentType}`);
+   */
+  return null;
 };

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -7,6 +7,7 @@ import type {
   RoutePattern,
 } from "./types.js";
 import { isSupportedMethod, isValidHandler, isValidRoute } from "./assert.js";
+import z from "zod";
 
 /**
  * Create a RegExp pattern from a route string. This function allows segment the
@@ -43,13 +44,13 @@ export const createRoutePattern = (route: RoutePattern): RegExp => {
 export const createEndpoint = <
   const Method extends Uppercase<HTTPMethod>,
   const Route extends Lowercase<RoutePattern>,
-  const Config extends EndpointConfig,
+  const Schemas extends EndpointSchemas,
 >(
   method: Method,
   route: Route,
-  handler: RouteHandler<Route, Config>,
-  config: Config = {} as Config,
-): RouteEndpoint<Method, Route, Config> => {
+  handler: RouteHandler<Route, { schemas: Schemas }>,
+  config: EndpointConfig<Route, Schemas> = {},
+): RouteEndpoint<Method, Route, {}> => {
   if (!isSupportedMethod(method)) {
     throw new Error(`Unsupported HTTP method: ${method}`);
   }
@@ -83,8 +84,11 @@ export const createEndpoint = <
  *   return new Response("Search results");
  * }, config);
  */
-export const createEndpointConfig = <Schemas extends EndpointSchemas>(
-  config: EndpointConfig<Schemas>,
+export const createEndpointConfig = <
+  Route extends RoutePattern,
+  Schemas extends EndpointSchemas = EndpointSchemas,
+>(
+  config: EndpointConfig<Route, Schemas>,
 ) => {
   return config;
 };

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -7,7 +7,6 @@ import type {
   RoutePattern,
 } from "./types.js";
 import { isSupportedMethod, isValidHandler, isValidRoute } from "./assert.js";
-import z from "zod";
 
 /**
  * Create a RegExp pattern from a route string. This function allows segment the
@@ -84,11 +83,15 @@ export const createEndpoint = <
  *   return new Response("Search results");
  * }, config);
  */
-export const createEndpointConfig = <
+export function createEndpointConfig<Schemas extends EndpointSchemas>(
+  config: EndpointConfig<RoutePattern, Schemas>,
+): EndpointConfig<RoutePattern, Schemas>;
+
+export function createEndpointConfig<
   Route extends RoutePattern,
-  Schemas extends EndpointSchemas = EndpointSchemas,
->(
-  config: EndpointConfig<Route, Schemas>,
-) => {
-  return config;
-};
+  S extends EndpointSchemas,
+>(route: Route, config: EndpointConfig<Route, S>): EndpointConfig<Route, S>;
+export function createEndpointConfig(...args: unknown[]) {
+  if (typeof args[0] === "string") return args[1];
+  return args[0];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { createEndpoint, createEndpointConfig } from "./endpoint.js";
 export { createRouter } from "./router.js";
+export type * from "./types.js"

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,57 @@
+import type {
+  EndpointConfig,
+  MiddlewareFunction,
+  RequestContext,
+  RouterConfig,
+} from "./types.js";
+
+/**
+ * Executes the middlewares in sequence, passing the request to each middleware.
+ *
+ * @param request - Original request made from the client
+ * @param middlewares - Array of global middleware functions to be executed
+ * @returns - The modified request after all middlewares have been executed
+ */
+export const executeGlobalMiddlewares = async (
+  request: Request,
+  middlewares: RouterConfig["middlewares"],
+) => {
+  if (!middlewares) return request;
+  for (const middleware of middlewares) {
+    if (typeof middleware !== "function") {
+      throw new TypeError("Middleware must be a function");
+    }
+    const executed = await middleware(request);
+    if (executed instanceof Response) {
+      return executed;
+    }
+    request = executed;
+  }
+  return request;
+};
+
+/**
+ * Executes middlewares in sequence, passing the request and context to each middleware.
+ *
+ * @param request - Original request made from the client
+ * @param context - Context object of the endpoint functionality
+ * @param middlewares - Array of middleware functions to be executed
+ * @returns The modified context after all middlewares have been executed
+ */
+export const executeMiddlewares = async <
+  const RouteParams extends Record<string, string>,
+  const Config extends EndpointConfig,
+>(
+  request: Request,
+  context: RequestContext<RouteParams, Config>,
+  middlewares: MiddlewareFunction<RouteParams, Config>[] = [],
+): Promise<RequestContext<RouteParams, Config>> => {
+  let ctx = context;
+  for (const middleware of middlewares) {
+    if (typeof middleware !== "function") {
+      throw new TypeError("Middleware must be a function");
+    }
+    ctx = await middleware(request, ctx);
+  }
+  return ctx;
+};

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,12 +1,12 @@
 import type {
   HTTPMethod,
-  InferMethod,
   RequestContext,
   RouteEndpoint,
   RoutePattern,
   RouterConfig,
   MiddlewareFunction,
   EndpointConfig,
+  GetHttpHandler,
 } from "./types.js";
 import { createRoutePattern } from "./endpoint.js";
 import {
@@ -54,18 +54,8 @@ export const executeMiddlewares = async <
 export const createRouter = <const Endpoints extends RouteEndpoint[]>(
   endpoints: Endpoints,
   config: RouterConfig = {},
-): {
-  [Method in InferMethod<Endpoints>]: (
-    req: Request,
-    ctx: RequestContext,
-  ) => Promise<Response>;
-} => {
-  const server = {} as {
-    [Method in InferMethod<Endpoints>]: (
-      req: Request,
-      ctx: RequestContext,
-    ) => Promise<Response>;
-  };
+): GetHttpHandler<Endpoints> => {
+  const server = {} as GetHttpHandler<Endpoints>;
   const groups: Record<HTTPMethod, RouteEndpoint[]> = {
     GET: [],
     POST: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,20 +76,22 @@ export type MiddlewareFunction<
   Config extends EndpointConfig = EndpointConfig,
 > = (
   request: Request,
-  ctx: RequestContext<RouteParams, Config>,
+  ctx: Prettify<RequestContext<RouteParams, Config>>,
 ) => Promise<RequestContext<RouteParams, Config>>;
 
 /**
  * Configuration for an endpoint, including optional schemas for request validation and middlewares.
  */
-export type EndpointConfig<Schemas extends EndpointSchemas = EndpointSchemas> =
-  {
-    schemas?: Schemas;
-    middlewares?: MiddlewareFunction<
-      Record<string, string>,
-      { schemas: Schemas }
-    >[];
-  };
+export type EndpointConfig<
+  RouteParams extends RoutePattern = RoutePattern,
+  Schemas extends EndpointSchemas = EndpointSchemas,
+> = Prettify<{
+  schemas?: Schemas;
+  middlewares?: MiddlewareFunction<
+    GetRouteParams<RouteParams>,
+    { schemas: Schemas }
+  >[];
+}>;
 
 /**
  * Infer the type of search parameters from the provided value in the `EndpointConfig`.
@@ -111,16 +113,15 @@ export type ContextBody<Schemas extends EndpointConfig["schemas"]> =
  * Context object passed to route handlers and middlewares defined in the
  * `createEndpoint/createEndpointConfig` function or globally in the `createRouter` function.
  */
-export type RequestContext<
+export interface RequestContext<
   RouteParams = Record<string, string>,
   Config extends EndpointConfig = EndpointConfig,
-> = Prettify<
-  {
-    params: RouteParams;
-    headers: Headers;
-  } & ContextBody<Config["schemas"]> &
-    ContextSearchParams<Config["schemas"]>
->;
+> {
+  params: RouteParams;
+  headers: Headers;
+  body: ContextBody<Config["schemas"]>["body"];
+  searchParams: ContextSearchParams<Config["schemas"]>["searchParams"];
+}
 
 /**
  * Defines a route handler function that processes an incoming request and returns a response.
@@ -132,27 +133,33 @@ export type RouteHandler<
   Config extends EndpointConfig,
 > = (
   request: Request,
-  ctx: RequestContext<GetRouteParams<Route>, Config>,
+  ctx: Prettify<RequestContext<GetRouteParams<Route>, Config>>,
 ) => Promise<Response>;
 
 /**
  * Represents a route endpoint definition, specifying the HTTP method, route pattern,
  * handler function with inferred context types, and associated configuration.
  */
-export type RouteEndpoint<
+export interface RouteEndpoint<
   Method extends HTTPMethod = HTTPMethod,
   Route extends RoutePattern = RoutePattern,
   Config extends EndpointConfig = EndpointConfig,
-> = {
+> {
   method: Method;
   route: Route;
   handler: RouteHandler<Route, Config>;
   config: Config;
-};
+}
 
 /**
  * Infer the HTTP methods defined in the provided array of route endpoints.
  */
-export type InferMethod<T extends RouteEndpoint[]> = T extends unknown[]
-  ? T[number]["method"]
-  : "unknown";
+export type InferMethod<Endpoints extends RouteEndpoint[]> =
+  Endpoints extends unknown[] ? Endpoints[number]["method"] : "unknown";
+
+export type GetHttpHandler<Endpoints extends RouteEndpoint[]> = {
+  [Method in InferMethod<Endpoints>]: (
+    req: Request,
+    ctx: RequestContext,
+  ) => Promise<Response>;
+};

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -1,6 +1,12 @@
+import z from "zod";
 import { describe, test } from "vitest";
-import { createEndpoint, createRoutePattern } from "../src/endpoint.js";
-import type { HTTPMethod, RoutePattern } from "../src/types.js";
+import { createRouter } from "../src/router.js";
+import {
+  createEndpoint,
+  createEndpointConfig,
+  createRoutePattern,
+} from "../src/endpoint.js";
+import type { HTTPMethod, RoutePattern, RequestContext } from "../src/types.js";
 
 describe("createRoutePattern", () => {
   const testCases = [
@@ -75,7 +81,6 @@ describe("createEndpoint", () => {
           method as HTTPMethod,
           route as Lowercase<RoutePattern>,
           handler,
-          {},
         );
         expect(endpoint).toEqual({ ...expected, handler });
       });
@@ -103,6 +108,233 @@ describe("createEndpoint", () => {
             {},
           ),
         ).toThrowError(expected);
+      });
+    });
+  });
+
+  describe("With schemas", () => {
+    describe("With body schema", () => {
+      const endpoint = createEndpoint(
+        "POST",
+        "/auth/credentials",
+        async (_, ctx) => {
+          return Response.json({ body: ctx.body });
+        },
+        {
+          schemas: {
+            body: z.object({
+              username: z.string(),
+              password: z.string(),
+            }),
+          },
+        },
+      );
+      const { POST } = createRouter([endpoint]);
+
+      test("With valid body", async ({ expect }) => {
+        const post = await POST(
+          new Request("https://example.com/auth/credentials", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ username: "John", password: "secret" }),
+          }),
+          {} as RequestContext,
+        );
+        expect(post.ok).toBe(true);
+        expect(await post.json()).toEqual({
+          body: { username: "John", password: "secret" },
+        });
+      });
+
+      test("With invalid body", async ({ expect }) => {
+        await expect(
+          POST(
+            new Request("https://example.com/auth/credentials", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ username: "John" }),
+            }),
+            {} as RequestContext,
+          ),
+        ).rejects.toThrowError(/Invalid request body/);
+      });
+    });
+
+    describe("With searchParams schema", () => {
+      const endpoint = createEndpoint(
+        "GET",
+        "/auth/:oauth",
+        async (_, ctx) => {
+          return Response.json({ searchParams: ctx.searchParams });
+        },
+        {
+          schemas: {
+            searchParams: z.object({
+              state: z.string(),
+              code: z.string(),
+            }),
+          },
+        },
+      );
+      const { GET } = createRouter([endpoint]);
+
+      test("With valid searchParams", async ({ expect }) => {
+        const get = await GET(
+          new Request("https://example.com/auth/google?state=123abc&code=123"),
+          {} as RequestContext,
+        );
+        expect(get.ok).toBe(true);
+        expect(await get.json()).toEqual({
+          searchParams: { state: "123abc", code: "123" },
+        });
+      });
+
+      test("With invalid searchParams", async ({ expect }) => {
+        await expect(
+          GET(
+            new Request("https://example.com/auth/google?state=123abc"),
+            {} as RequestContext,
+          ),
+        ).rejects.toThrowError(/Invalid search parameters/);
+      });
+    });
+  });
+
+  describe("With middlewares", () => {
+    test("Update params context in middleware", async ({ expect }) => {
+      const endpoint = createEndpoint(
+        "GET",
+        "/auth/:oauth",
+        async (_, ctx) => {
+          const oauth = ctx.params.oauth;
+          return Response.json({ oauth });
+        },
+        {
+          middlewares: [
+            async (_, ctx) => {
+              ctx.params = { oauth: "google" };
+              return ctx;
+            },
+          ],
+        },
+      );
+      const { GET } = createRouter([endpoint]);
+      const get = await GET(
+        new Request("https://example.com/auth/github"),
+        {} as RequestContext,
+      );
+      expect(get.ok).toBe(true);
+      expect(await get.json()).toEqual({ oauth: "google" });
+    });
+
+    test("Update searchParams context in middleware", async ({ expect }) => {
+      const endpoint = createEndpoint(
+        "GET",
+        "/auth/google",
+        async (_, ctx) => {
+          const searchParams = Object.fromEntries(ctx.searchParams.entries());
+          return Response.json({ searchParams });
+        },
+        {
+          middlewares: [
+            async (_, ctx) => {
+              ctx.searchParams.set("state", "123abc");
+              ctx.searchParams.set("code", "123");
+              return ctx;
+            },
+          ],
+        },
+      );
+      const { GET } = createRouter([endpoint]);
+      const get = await GET(
+        new Request("https://example.com/auth/google"),
+        {} as RequestContext,
+      );
+      expect(get.ok).toBe(true);
+      expect(await get.json()).toEqual({
+        searchParams: { state: "123abc", code: "123" },
+      });
+    });
+
+    test("Update headers context in middleware", async ({ expect }) => {
+      const endpoint = createEndpoint(
+        "GET",
+        "/headers",
+        async (_, ctx) => {
+          const headers = Object.fromEntries(ctx.headers.entries());
+          return Response.json({ headers });
+        },
+        {
+          middlewares: [
+            async (_, ctx) => {
+              ctx.headers.set("Authorization", "Bearer token");
+              return ctx;
+            },
+          ],
+        },
+      );
+      const { GET } = createRouter([endpoint]);
+      const get = await GET(
+        new Request("https://example.com/headers"),
+        {} as RequestContext,
+      );
+      expect(get.ok).toBe(true);
+      expect(await get.json()).toEqual({
+        headers: { authorization: "Bearer token" },
+      });
+    });
+  });
+
+  describe("With schemas and middlewares", () => {
+    const config = createEndpointConfig({
+      schemas: {
+        body: z.object({
+          username: z.string(),
+          password: z.string(),
+        }),
+      },
+      middlewares: [
+        async (_, ctx) => {
+          ctx.body;
+          return ctx;
+        },
+      ],
+    });
+
+    const endpoint = createEndpoint(
+      "POST",
+      "/auth/credentials",
+      async (_, ctx) => {
+        return Response.json({ body: ctx.body });
+      },
+      {
+        schemas: {
+          body: z.object({
+            username: z.string(),
+            password: z.string(),
+          }),
+        },
+        middlewares: [
+          async (_, ctx) => {
+            return ctx;
+          },
+        ],
+      },
+    );
+    const { POST } = createRouter([endpoint]);
+
+    test("With valid body", async ({ expect }) => {
+      const post = await POST(
+        new Request("https://example.com/auth/credentials", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ username: "John", password: "secret" }),
+        }),
+        {} as RequestContext,
+      );
+      expect(post.ok).toBe(true);
+      expect(await post.json()).toEqual({
+        body: { username: "John", password: "secret" },
       });
     });
   });

--- a/test/middlewares.test.ts
+++ b/test/middlewares.test.ts
@@ -1,0 +1,185 @@
+import z from "zod";
+import { describe, expect, test } from "vitest";
+import {
+  executeGlobalMiddlewares,
+  executeMiddlewares,
+} from "../src/middleware.js";
+import type { MiddlewareFunction, RequestContext } from "../src/types.js";
+
+describe("executeGlobalMiddlewares", () => {
+  test("No middlewares", async () => {
+    const request = new Request("https://example.com");
+    const result = await executeGlobalMiddlewares(request, undefined);
+    expect(result).toEqual(request);
+  });
+
+  test("Single middleware that modifies request", async () => {
+    const request = new Request("https://example.com");
+    const middleware = async (req: Request) => {
+      const newHeaders = new Headers(req.headers);
+      newHeaders.set("X-Test", "true");
+      return new Request(req, { headers: newHeaders });
+    };
+    const result = await executeGlobalMiddlewares(request, [middleware]);
+    expect(result.headers.get("X-Test")).toBe("true");
+    expect(request.headers.get("X-Test")).toBeNull();
+  });
+
+  test("Middleware updates headers directly", async () => {
+    const request = new Request("https://example.com");
+    const middleware = async (req: Request) => {
+      req.headers.set("X-Test-Direct", "true");
+      return req;
+    };
+    const result = await executeGlobalMiddlewares(request, [middleware]);
+    expect(result.headers.get("X-Test-Direct")).toBe("true");
+    expect(request.headers.get("X-Test-Direct")).toBe("true");
+  });
+
+  test("Multiple middlewares", async () => {
+    const request = new Request("https://example.com");
+    const middleware1 = async (req: Request) => {
+      const newHeaders = new Headers(req.headers);
+      newHeaders.set("X-Test-1", "true");
+      return new Request(req, { headers: newHeaders });
+    };
+    const middleware2 = async (req: Request) => {
+      const newHeaders = new Headers(req.headers);
+      newHeaders.set("X-Test-2", "true");
+      return new Request(req, { headers: newHeaders });
+    };
+    const result = await executeGlobalMiddlewares(request, [
+      middleware1,
+      middleware2,
+    ]);
+    expect(result.headers.get("X-Test-1")).toBe("true");
+    expect(result.headers.get("X-Test-2")).toBe("true");
+    expect(request.headers.get("X-Test-1")).toBeNull();
+    expect(request.headers.get("X-Test-2")).toBeNull();
+  });
+
+  test("Middleware that returns a Response", async () => {
+    const request = new Request("https://example.com");
+    const middleware = async () => {
+      return new Response("Blocked", { status: 403 });
+    };
+    const result = await executeGlobalMiddlewares(request, [middleware]);
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(403);
+  });
+});
+
+describe("executeMiddlewares", () => {
+  test.concurrent(
+    "Middleware with searchParams and headers context",
+    async ({ expect }) => {
+      const middlewares: MiddlewareFunction[] = [
+        async (_, ctx) => {
+          ctx.searchParams.set("code", "123abc");
+          ctx.headers.set("Content-Type", "application/json");
+          return ctx;
+        },
+      ];
+      const ctx = await executeMiddlewares(
+        new Request("https://example.com"),
+        {
+          searchParams: new URL("https://example.com").searchParams,
+          headers: new Headers(),
+        } as RequestContext,
+        middlewares,
+      );
+      expect(ctx.searchParams.get("code")).toBe("123abc");
+      expect(ctx.headers.get("Content-Type")).toBe("application/json");
+    },
+  );
+
+  test.concurrent(
+    "Two middlewares with searchParams and headers context",
+    async ({ expect }) => {
+      const middlewares: MiddlewareFunction[] = [
+        async (_, ctx) => {
+          ctx.searchParams.set("code", "123abc");
+          ctx.searchParams.set("state", "xyz");
+          return ctx;
+        },
+        async (_, ctx) => {
+          ctx.searchParams.set("state", "abc");
+          ctx.headers.set("Authorization", "Bearer token");
+          return ctx;
+        },
+      ];
+      const ctx = await executeMiddlewares(
+        new Request("https://example.com"),
+        {
+          searchParams: new URL("https://example.com").searchParams,
+          headers: new Headers(),
+        } as RequestContext,
+        middlewares,
+      );
+      expect(ctx.searchParams.get("code")).toBe("123abc");
+      expect(ctx.searchParams.get("state")).toBe("abc");
+      expect(ctx.headers.get("Authorization")).toBe("Bearer token");
+    },
+  );
+
+  test.concurrent("Invalid middleware", async ({ expect }) => {
+    const middlewares: MiddlewareFunction[] = [undefined as any];
+    await expect(
+      executeMiddlewares(
+        new Request("https://example.com"),
+        {
+          searchParams: new URL("https://example.com").searchParams,
+          headers: new Headers(),
+        } as RequestContext,
+        middlewares,
+      ),
+    ).rejects.toThrowError(/Middleware must be a function/);
+  });
+
+  test.concurrent("No middleware", async ({ expect }) => {
+    const ctx = await executeMiddlewares(new Request("https://example.com"), {
+      searchParams: new URL("https://example.com").searchParams,
+      headers: new Headers(),
+    } as RequestContext);
+    expect(ctx.searchParams.get("code")).toBe(null);
+    expect(ctx.searchParams.get("state")).toBe(null);
+    expect(ctx.headers.get("Content-Type")).toBe(null);
+  });
+
+  test.concurrent("Middleware with schema", async ({ expect }) => {
+    const searchParamsShema = z.object({
+      code: z.string().optional,
+      state: z.string().optional(),
+    });
+    const middlewares: MiddlewareFunction<
+      Record<string, string>,
+      { schemas: { searchParams: typeof searchParamsShema } }
+    >[] = [
+      async (_, ctx) => {
+        ctx.searchParams.code = "123abc";
+        ctx.searchParams.state = "xyz";
+        return ctx;
+      },
+    ];
+
+    const ctx = await executeMiddlewares(
+      new Request("https://example.com"),
+      {
+        headers: new Headers(),
+        searchParams: {
+          code: "123abc",
+          state: "xyz",
+        },
+        params: {},
+        body: undefined,
+      } as RequestContext<
+        Record<string, string>,
+        { schemas: { searchParams: typeof searchParamsShema } }
+      >,
+      middlewares,
+    );
+
+    expect(ctx.searchParams.code).toBe("123abc");
+    expect(ctx.searchParams.state).toBe("xyz");
+  });
+});

--- a/test/type.test-d.ts
+++ b/test/type.test-d.ts
@@ -12,7 +12,7 @@ import type {
   InferMethod,
   EndpointSchemas,
 } from "../src/types.js";
-import { ZodObject, ZodString } from "zod";
+import type { ZodObject, ZodString } from "zod";
 
 /**
  * @todo: implement runtime tests for the types
@@ -209,13 +209,13 @@ describe("MiddlewareFunction", () => {
    */
   expectTypeOf<
     MiddlewareFunction<
-      { oauth: string },
+      GetRouteParams<"/auth/:oauth">,
       {
         middlewares: [
           (
             request: Request,
-            ctx: RequestContext<{ oauth: string }>,
-          ) => Promise<RequestContext<{ oauth: string }, { middlewares: [] }>>,
+            ctx: RequestContext<GetRouteParams<"/auth/:oauth">>,
+          ) => Promise<RequestContext>,
         ];
       }
     >
@@ -381,6 +381,22 @@ describe("EndpointConfig", () => {
       Record<string, string>,
       {
         schemas: EndpointSchemas;
+      }
+    >[];
+  }>();
+
+  expectTypeOf<
+    EndpointConfig<{
+      body: ZodObject<{ username: ZodString; password: ZodString }>;
+    }>
+  >().toEqualTypeOf<{
+    schemas?: { body: ZodObject<{ username: ZodString; password: ZodString }> };
+    middlewares?: MiddlewareFunction<
+      Record<string, string>,
+      {
+        schemas: {
+          body: ZodObject<{ username: ZodString; password: ZodString }>;
+        };
       }
     >[];
   }>();

--- a/test/type.test-d.ts
+++ b/test/type.test-d.ts
@@ -208,22 +208,30 @@ describe("MiddlewareFunction", () => {
    * @todo: fix the error inference on nested middlewares
    */
   expectTypeOf<
-    MiddlewareFunction<
-      GetRouteParams<"/auth/:oauth">,
-      {
-        middlewares: [
-          (
-            request: Request,
-            ctx: RequestContext<GetRouteParams<"/auth/:oauth">>,
-          ) => Promise<RequestContext>,
-        ];
-      }
-    >
+    MiddlewareFunction<GetRouteParams<"/auth/:oauth">>
   >().toEqualTypeOf<
     (
       request: Request,
       ctx: RequestContext<{ oauth: string }, { middlewares: [] }>,
     ) => Promise<RequestContext<{ oauth: string }, { middlewares: [] }>>
+  >();
+
+  expectTypeOf<
+    MiddlewareFunction<
+      GetRouteParams<"/auth/:oauth">,
+      {
+        schemas: { searchParams: ZodObject<{ state: ZodString }> };
+        middlewares: [];
+      }
+    >
+  >().toEqualTypeOf<
+    (
+      request: Request,
+      ctx: RequestContext<
+        GetRouteParams<"/auth/:oauth">,
+        { schemas: { searchParams: ZodObject<{ state: ZodString }> } }
+      >,
+    ) => Promise<RequestContext<GetRouteParams<"/auth/:oauth">, {}>>
   >();
 });
 
@@ -378,7 +386,7 @@ describe("EndpointConfig", () => {
   expectTypeOf<EndpointConfig>().toEqualTypeOf<{
     schemas?: EndpointSchemas;
     middlewares?: MiddlewareFunction<
-      Record<string, string>,
+      GetRouteParams<"/">,
       {
         schemas: EndpointSchemas;
       }
@@ -386,13 +394,16 @@ describe("EndpointConfig", () => {
   }>();
 
   expectTypeOf<
-    EndpointConfig<{
-      body: ZodObject<{ username: ZodString; password: ZodString }>;
-    }>
+    EndpointConfig<
+      "/",
+      {
+        body: ZodObject<{ username: ZodString; password: ZodString }>;
+      }
+    >
   >().toEqualTypeOf<{
     schemas?: { body: ZodObject<{ username: ZodString; password: ZodString }> };
     middlewares?: MiddlewareFunction<
-      Record<string, string>,
+      GetRouteParams<"/">,
       {
         schemas: {
           body: ZodObject<{ username: ZodString; password: ZodString }>;


### PR DESCRIPTION
## Description

This pull request introduces **middleware support** to the core functions, with strong **TypeScript type inference** to ensure proper autocompletion and configuration assistance for users. Currently, two functions support middleware: `createRouter` and `createEndpoint`, each with distinct middleware behaviors. The main goal of this feature is to provide controlled access and processing before executing specific layers of the application.

The `createRouter` function now supports **global middlewares**, which run before route matching. These middlewares receive the original request and can modify it or terminate execution early by returning a response.

In contrast, the `createEndpoint` function supports **handler middlewares**, which execute before the main handler. These middlewares have access to the parsed context — including `body`, `searchParams`, `params`, and `headers`. To improve type inference for `body` and `searchParams`, users can define a Zod schema through the configuration options.

Finally, the `createEndpointConfig` function allows developers to define endpoint configurations declaratively, with full type inference support.

### Key Changes
- **`createRouter`**: Adds support for global middlewares (executed before route matching).  
- **`createEndpoint`**: Adds support for handler middlewares (executed before the handler) with access to parsed context.  
- **`createEndpointConfig`**: Introduces a declarative way to define endpoint configurations with type inference.
