### PR TITLE
style(prettier): export config and format code

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ yarn add @aura-stack/router
 ## Quick Start
 
 ```ts
-import { createEndpoint, createRouter } from "@aura-stack/router";
+import { createEndpoint, createRouter } from "@aura-stack/router"
 
 const session = createEndpoint("GET", "/auth/session", async (_, ctx) => {
   return Response.json(
@@ -43,18 +43,18 @@ const session = createEndpoint("GET", "/auth/session", async (_, ctx) => {
         username: "John",
       },
     },
-    { headers: ctx.headers },
-  );
-});
+    { headers: ctx.headers }
+  )
+})
 
-const { GET } = createRouter([session]);
+const { GET } = createRouter([session])
 ```
 
 ## Defining Endpoints
 
 ```ts
-import { z } from "zod";
-import { createEndpoint, createEndpointConfig } from "@aura-stack/router";
+import { z } from "zod"
+import { createEndpoint, createEndpointConfig } from "@aura-stack/router"
 
 const credentialsConfig = createEndpointConfig({
   schemas: {
@@ -63,18 +63,18 @@ const credentialsConfig = createEndpointConfig({
       password: z.string(),
     }),
   },
-});
+})
 
 export const signIn = createEndpoint(
   "POST",
   "/auth/credentials",
   async (request, ctx) => {
-    const { body, headers } = ctx;
-    headers.set("x-login", "success");
-    return Response.json({ status: "ok", body }, { headers });
+    const { body, headers } = ctx
+    headers.set("x-login", "success")
+    return Response.json({ status: "ok", body }, { headers })
   },
-  credentialsConfig,
-);
+  credentialsConfig
+)
 ```
 
 ## Validation & Middlewares
@@ -82,7 +82,7 @@ export const signIn = createEndpoint(
 **Validation.** Provide Zod schemas in `createEndpointConfig`:
 
 ```ts
-import { createEndpoint, createEndpointConfig } from "@aura-stack/router";
+import { createEndpoint, createEndpointConfig } from "@aura-stack/router"
 
 const config = createEndpointConfig({
   schemas: {
@@ -90,18 +90,18 @@ const config = createEndpointConfig({
       redirect_uri: z.string(),
     }),
   },
-});
+})
 
 const oauth = createEndpoint(
   "GET",
   "/auth/signin/:provider",
   async (_req, ctx) => {
-    const { provider } = ctx.params;
-    const { redirect_uri } = ctx.searchParams;
-    return Response.json({ provider, redirect_uri }, { status: 302 });
+    const { provider } = ctx.params
+    const { redirect_uri } = ctx.searchParams
+    return Response.json({ provider, redirect_uri }, { status: 302 })
   },
-  config,
-);
+  config
+)
 ```
 
 If validation fails, the helper throws an informative error before your handler executes.
@@ -109,14 +109,14 @@ If validation fails, the helper throws an informative error before your handler 
 **Middlewares.** Provide async middleware functions to read or modify the request.
 
 ```ts
-import { createRouter, type GlobalMiddleware } from "@aura-stack/router";
+import { createRouter, type GlobalMiddleware } from "@aura-stack/router"
 
 const audit: GlobalMiddleware = async (request) => {
-  request.headers.set("x-request-id", crypto.randomUUID());
-  return request;
-};
+  request.headers.set("x-request-id", crypto.randomUUID())
+  return request
+}
 
-const router = createRouter([oauth], { middlewares: [audit] });
+const router = createRouter([oauth], { middlewares: [audit] })
 ```
 
 ## API Reference

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -2,16 +2,18 @@
  * @type {import("prettier").Config}
  */
 export const config = {
-  semi: false,
-  tabWidth: 4,
-  printWidth: 130,
-  trailingComma: "es5",
-  overrides: [
-    {
-      files: ["*.json", "*.md", "*.mdx", "*.yaml", "*.yml"],
-      options: {
-        tabWidth: 2,
-      },
-    },
-  ],
-};
+    semi: false,
+    tabWidth: 4,
+    printWidth: 130,
+    trailingComma: "es5",
+    overrides: [
+        {
+            files: ["*.json", "*.md", "*.mdx", "*.yaml", "*.yml"],
+            options: {
+                tabWidth: 2,
+            },
+        },
+    ],
+}
+
+export default config

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -1,14 +1,8 @@
-import type { RouteHandler, HTTPMethod, RoutePattern } from "./types.js";
+import type { RouteHandler, HTTPMethod, RoutePattern } from "./types.js"
 
-const supportedMethods: HTTPMethod[] = [
-  "GET",
-  "POST",
-  "DELETE",
-  "PUT",
-  "PATCH",
-];
+const supportedMethods: HTTPMethod[] = ["GET", "POST", "DELETE", "PUT", "PATCH"]
 
-const supportedBodyMethods: HTTPMethod[] = ["POST", "PUT", "PATCH"];
+const supportedBodyMethods: HTTPMethod[] = ["POST", "PUT", "PATCH"]
 
 /**
  * Checks if the provided method is a supported HTTP method.
@@ -17,8 +11,8 @@ const supportedBodyMethods: HTTPMethod[] = ["POST", "PUT", "PATCH"];
  * @returns True if the method is supported, false otherwise.
  */
 export const isSupportedMethod = (method: string): method is HTTPMethod => {
-  return supportedMethods.includes(method as HTTPMethod);
-};
+    return supportedMethods.includes(method as HTTPMethod)
+}
 
 /**
  * Check if the provided method can includes a body as per HTTP specification.
@@ -26,8 +20,8 @@ export const isSupportedMethod = (method: string): method is HTTPMethod => {
  * @returns True if the method can include a body, false otherwise.
  */
 export const isSupportedBodyMethod = (method: string): method is HTTPMethod => {
-  return supportedBodyMethods.includes(method as HTTPMethod);
-};
+    return supportedBodyMethods.includes(method as HTTPMethod)
+}
 
 /**
  * Checks if the provided route is a valid route pattern.
@@ -36,9 +30,9 @@ export const isSupportedBodyMethod = (method: string): method is HTTPMethod => {
  * @returns True if the route is valid, false otherwise.
  */
 export const isValidRoute = (route: string): route is RoutePattern => {
-  const routePattern = /^\/[a-zA-Z0-9/_:-]*$/;
-  return routePattern.test(route);
-};
+    const routePattern = /^\/[a-zA-Z0-9/_:-]*$/
+    return routePattern.test(route)
+}
 
 /**
  * Checks if the provided handler is a valid route handler function.
@@ -46,8 +40,6 @@ export const isValidRoute = (route: string): route is RoutePattern => {
  * @param handler - The handler to check.
  * @returns True if the handler is valid, false otherwise.
  */
-export const isValidHandler = (
-  handler: unknown,
-): handler is RouteHandler<any, any> => {
-  return typeof handler === "function";
-};
+export const isValidHandler = (handler: unknown): handler is RouteHandler<any, any> => {
+    return typeof handler === "function"
+}

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,12 +1,5 @@
-import type {
-  EndpointConfig,
-  EndpointSchemas,
-  HTTPMethod,
-  RouteEndpoint,
-  RouteHandler,
-  RoutePattern,
-} from "./types.js";
-import { isSupportedMethod, isValidHandler, isValidRoute } from "./assert.js";
+import type { EndpointConfig, EndpointSchemas, HTTPMethod, RouteEndpoint, RouteHandler, RoutePattern } from "./types.js"
+import { isSupportedMethod, isValidHandler, isValidRoute } from "./assert.js"
 
 /**
  * Create a RegExp pattern from a route string. This function allows segment the
@@ -20,9 +13,9 @@ import { isSupportedMethod, isValidHandler, isValidRoute } from "./assert.js";
  * const pattern = createRoutePattern("/users/:id");
  */
 export const createRoutePattern = (route: RoutePattern): RegExp => {
-  const pattern = route.replace(/:[^/]+/g, "([^/]+)").replace(/\//g, "\\/");
-  return new RegExp(`^${pattern}$`);
-};
+    const pattern = route.replace(/:[^/]+/g, "([^/]+)").replace(/\//g, "\\/")
+    return new RegExp(`^${pattern}$`)
+}
 
 /**
  * Defines an API endpoint for the router by specifying the HTTP method, route pattern,
@@ -41,26 +34,26 @@ export const createRoutePattern = (route: RoutePattern): RegExp => {
  * });
  */
 export const createEndpoint = <
-  const Method extends Uppercase<HTTPMethod>,
-  const Route extends Lowercase<RoutePattern>,
-  const Schemas extends EndpointSchemas,
+    const Method extends Uppercase<HTTPMethod>,
+    const Route extends Lowercase<RoutePattern>,
+    const Schemas extends EndpointSchemas,
 >(
-  method: Method,
-  route: Route,
-  handler: RouteHandler<Route, { schemas: Schemas }>,
-  config: EndpointConfig<Route, Schemas> = {},
+    method: Method,
+    route: Route,
+    handler: RouteHandler<Route, { schemas: Schemas }>,
+    config: EndpointConfig<Route, Schemas> = {}
 ): RouteEndpoint<Method, Route, {}> => {
-  if (!isSupportedMethod(method)) {
-    throw new Error(`Unsupported HTTP method: ${method}`);
-  }
-  if (!isValidRoute(route)) {
-    throw new Error(`Invalid route format: ${route}`);
-  }
-  if (!isValidHandler(handler)) {
-    throw new Error("Handler must be a function");
-  }
-  return { method, route, handler, config };
-};
+    if (!isSupportedMethod(method)) {
+        throw new Error(`Unsupported HTTP method: ${method}`)
+    }
+    if (!isValidRoute(route)) {
+        throw new Error(`Invalid route format: ${route}`)
+    }
+    if (!isValidHandler(handler)) {
+        throw new Error("Handler must be a function")
+    }
+    return { method, route, handler, config }
+}
 
 /**
  * Create an endpoint configuration to be passed to the `createEndpoint` function.
@@ -84,14 +77,14 @@ export const createEndpoint = <
  * }, config);
  */
 export function createEndpointConfig<Schemas extends EndpointSchemas>(
-  config: EndpointConfig<RoutePattern, Schemas>,
-): EndpointConfig<RoutePattern, Schemas>;
+    config: EndpointConfig<RoutePattern, Schemas>
+): EndpointConfig<RoutePattern, Schemas>
 
-export function createEndpointConfig<
-  Route extends RoutePattern,
-  S extends EndpointSchemas,
->(route: Route, config: EndpointConfig<Route, S>): EndpointConfig<Route, S>;
+export function createEndpointConfig<Route extends RoutePattern, S extends EndpointSchemas>(
+    route: Route,
+    config: EndpointConfig<Route, S>
+): EndpointConfig<Route, S>
 export function createEndpointConfig(...args: unknown[]) {
-  if (typeof args[0] === "string") return args[1];
-  return args[0];
+    if (typeof args[0] === "string") return args[1]
+    return args[0]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { createEndpoint, createEndpointConfig } from "./endpoint.js";
-export { createRouter } from "./router.js";
+export { createEndpoint, createEndpointConfig } from "./endpoint.js"
+export { createRouter } from "./router.js"
 export type * from "./types.js"

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,4 @@
-import type {
-  EndpointConfig,
-  MiddlewareFunction,
-  RequestContext,
-  RouterConfig,
-} from "./types.js";
+import type { EndpointConfig, MiddlewareFunction, RequestContext, RouterConfig } from "./types.js"
 
 /**
  * Executes the middlewares in sequence, passing the request to each middleware.
@@ -12,23 +7,20 @@ import type {
  * @param middlewares - Array of global middleware functions to be executed
  * @returns - The modified request after all middlewares have been executed
  */
-export const executeGlobalMiddlewares = async (
-  request: Request,
-  middlewares: RouterConfig["middlewares"],
-) => {
-  if (!middlewares) return request;
-  for (const middleware of middlewares) {
-    if (typeof middleware !== "function") {
-      throw new TypeError("Middleware must be a function");
+export const executeGlobalMiddlewares = async (request: Request, middlewares: RouterConfig["middlewares"]) => {
+    if (!middlewares) return request
+    for (const middleware of middlewares) {
+        if (typeof middleware !== "function") {
+            throw new TypeError("Middleware must be a function")
+        }
+        const executed = await middleware(request)
+        if (executed instanceof Response) {
+            return executed
+        }
+        request = executed
     }
-    const executed = await middleware(request);
-    if (executed instanceof Response) {
-      return executed;
-    }
-    request = executed;
-  }
-  return request;
-};
+    return request
+}
 
 /**
  * Executes middlewares in sequence, passing the request and context to each middleware.
@@ -38,20 +30,17 @@ export const executeGlobalMiddlewares = async (
  * @param middlewares - Array of middleware functions to be executed
  * @returns The modified context after all middlewares have been executed
  */
-export const executeMiddlewares = async <
-  const RouteParams extends Record<string, string>,
-  const Config extends EndpointConfig,
->(
-  request: Request,
-  context: RequestContext<RouteParams, Config>,
-  middlewares: MiddlewareFunction<RouteParams, Config>[] = [],
+export const executeMiddlewares = async <const RouteParams extends Record<string, string>, const Config extends EndpointConfig>(
+    request: Request,
+    context: RequestContext<RouteParams, Config>,
+    middlewares: MiddlewareFunction<RouteParams, Config>[] = []
 ): Promise<RequestContext<RouteParams, Config>> => {
-  let ctx = context;
-  for (const middleware of middlewares) {
-    if (typeof middleware !== "function") {
-      throw new TypeError("Middleware must be a function");
+    let ctx = context
+    for (const middleware of middlewares) {
+        if (typeof middleware !== "function") {
+            throw new TypeError("Middleware must be a function")
+        }
+        ctx = await middleware(request, ctx)
     }
-    ctx = await middleware(request, ctx);
-  }
-  return ctx;
-};
+    return ctx
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,19 +1,7 @@
-import type {
-  HTTPMethod,
-  RequestContext,
-  RouteEndpoint,
-  RoutePattern,
-  RouterConfig,
-  GetHttpHandlers,
-} from "./types.js";
-import { createRoutePattern } from "./endpoint.js";
-import {
-  getBody,
-  getHeaders,
-  getRouteParams,
-  getSearchParams,
-} from "./context.js";
-import { executeGlobalMiddlewares, executeMiddlewares } from "./middleware.js";
+import type { HTTPMethod, RequestContext, RouteEndpoint, RoutePattern, RouterConfig, GetHttpHandlers } from "./types.js"
+import { createRoutePattern } from "./endpoint.js"
+import { getBody, getHeaders, getRouteParams, getSearchParams } from "./context.js"
+import { executeGlobalMiddlewares, executeMiddlewares } from "./middleware.js"
 
 /**
  * Creates the entry point for the server, handling the endpoints defined in the router.
@@ -25,66 +13,49 @@ import { executeGlobalMiddlewares, executeMiddlewares } from "./middleware.js";
  * @returns An object with methods corresponding to HTTP methods, each handling requests for that method
  */
 export const createRouter = <const Endpoints extends RouteEndpoint[]>(
-  endpoints: Endpoints,
-  config: RouterConfig = {},
+    endpoints: Endpoints,
+    config: RouterConfig = {}
 ): GetHttpHandlers<Endpoints> => {
-  const server = {} as GetHttpHandlers<Endpoints>;
-  const groups: Record<HTTPMethod, RouteEndpoint[]> = {
-    GET: [],
-    POST: [],
-    DELETE: [],
-    PUT: [],
-    PATCH: [],
-  };
-  endpoints.forEach((endpoint) => groups[endpoint.method].push(endpoint));
-  for (const method in groups) {
-    server[method as keyof typeof server] = async (
-      request: Request,
-      ctx: RequestContext,
-    ) => {
-      const globalRequest = await executeGlobalMiddlewares(
-        request,
-        config.middlewares,
-      );
-      if (globalRequest instanceof Response) {
-        return globalRequest;
-      }
-      const url = new URL(globalRequest.url);
-      const pathname = url.pathname;
-      const endpoint = groups[method as HTTPMethod].find((endpoint) => {
-        const withBasePath = config.basePath
-          ? `${config.basePath}${endpoint.route}`
-          : endpoint.route;
-        const regex = createRoutePattern(withBasePath as RoutePattern);
-        return regex.test(pathname);
-      });
-      if (endpoint) {
-        const withBasePath = config.basePath
-          ? `${config.basePath}${endpoint.route}`
-          : endpoint.route;
-        const body = await getBody(globalRequest, endpoint.config);
-        const params = getRouteParams(withBasePath as RoutePattern, pathname);
-        const searchParams = getSearchParams(
-          globalRequest.url,
-          endpoint.config,
-        );
-        const headers = getHeaders(globalRequest);
-        const context = {
-          ...ctx,
-          params,
-          searchParams,
-          headers,
-          body,
-        } as RequestContext<Record<string, string>, typeof endpoint.config>;
-        await executeMiddlewares(
-          globalRequest,
-          context,
-          endpoint.config.middlewares,
-        );
-        return endpoint.handler(globalRequest, context);
-      }
-      return Response.json({ message: "Not Found" }, { status: 404 });
-    };
-  }
-  return server;
-};
+    const server = {} as GetHttpHandlers<Endpoints>
+    const groups: Record<HTTPMethod, RouteEndpoint[]> = {
+        GET: [],
+        POST: [],
+        DELETE: [],
+        PUT: [],
+        PATCH: [],
+    }
+    endpoints.forEach((endpoint) => groups[endpoint.method].push(endpoint))
+    for (const method in groups) {
+        server[method as keyof typeof server] = async (request: Request, ctx: RequestContext) => {
+            const globalRequest = await executeGlobalMiddlewares(request, config.middlewares)
+            if (globalRequest instanceof Response) {
+                return globalRequest
+            }
+            const url = new URL(globalRequest.url)
+            const pathname = url.pathname
+            const endpoint = groups[method as HTTPMethod].find((endpoint) => {
+                const withBasePath = config.basePath ? `${config.basePath}${endpoint.route}` : endpoint.route
+                const regex = createRoutePattern(withBasePath as RoutePattern)
+                return regex.test(pathname)
+            })
+            if (endpoint) {
+                const withBasePath = config.basePath ? `${config.basePath}${endpoint.route}` : endpoint.route
+                const body = await getBody(globalRequest, endpoint.config)
+                const params = getRouteParams(withBasePath as RoutePattern, pathname)
+                const searchParams = getSearchParams(globalRequest.url, endpoint.config)
+                const headers = getHeaders(globalRequest)
+                const context = {
+                    ...ctx,
+                    params,
+                    searchParams,
+                    headers,
+                    body,
+                } as RequestContext<Record<string, string>, typeof endpoint.config>
+                await executeMiddlewares(globalRequest, context, endpoint.config.middlewares)
+                return endpoint.handler(globalRequest, context)
+            }
+            return Response.json({ message: "Not Found" }, { status: 404 })
+        }
+    }
+    return server
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { type ZodObject, z } from "zod";
+import { type ZodObject, z } from "zod"
 
 /**
  * Route pattern must start with a slash and can contain parameters prefixed with a colon.
@@ -6,32 +6,29 @@ import { type ZodObject, z } from "zod";
  * const getUser:RoutePattern = "/users/:userId"
  * const getPostsComments:RoutePattern = "/posts/:postId/comments/:commentId"
  */
-export type RoutePattern = `/${string}`;
+export type RoutePattern = `/${string}`
 
 /**
  * HTTP methods supported by the router.
  */
-export type HTTPMethod = "GET" | "POST" | "DELETE" | "PUT" | "PATCH";
+export type HTTPMethod = "GET" | "POST" | "DELETE" | "PUT" | "PATCH"
 
 /**
  * Content types supported by the router.
  */
-export type ContentType =
-  | "application/json"
-  | "application/x-www-form-urlencoded"
-  | "text/plain";
+export type ContentType = "application/json" | "application/x-www-form-urlencoded" | "text/plain"
 
 /**
  * Configuration options for `createRouter` function.
  */
 export interface RouterConfig {
-  basePath?: RoutePattern;
-  middlewares?: GlobalMiddleware[];
+    basePath?: RoutePattern
+    middlewares?: GlobalMiddleware[]
 }
 
 export type Prettify<Obj extends object> = {
-  [Key in keyof Obj]: Obj[Key];
-} & {};
+    [Key in keyof Obj]: Obj[Key]
+} & {}
 
 /**
  * Extracts route parameters from a given route pattern through colon-prefixed segments.
@@ -48,86 +45,72 @@ export type Prettify<Obj extends object> = {
  * // Expected: {}
  * type NoParams = Params<"/about">;
  */
-export type Params<Route extends RoutePattern> =
-  Route extends `/${string}/:${infer Param}/${infer Str}`
+export type Params<Route extends RoutePattern> = Route extends `/${string}/:${infer Param}/${infer Str}`
     ? Prettify<{ [K in Param]: string } & Params<`/${Str}`>>
     : Route extends `/${string}/:${infer Param}`
       ? Prettify<{ [K in Param]: string }>
       : Route extends `/:${infer Param}`
         ? Prettify<{ [K in Param]: string }>
-        : {};
+        : {}
 
-export type GetRouteParams<T extends RoutePattern> = Params<T>;
+export type GetRouteParams<T extends RoutePattern> = Params<T>
 
 /**
  * Available schemas validation for an endpoint. It can include body and searchParams schemas.
  */
 export interface EndpointSchemas {
-  body?: ZodObject<any>;
-  searchParams?: ZodObject<any>;
+    body?: ZodObject<any>
+    searchParams?: ZodObject<any>
 }
 
 /**
  * Global middleware function type that represent a function that runs before the route matching.
  */
-export type GlobalMiddleware = (
-  request: Request,
-) => Promise<Request | Response>;
+export type GlobalMiddleware = (request: Request) => Promise<Request | Response>
 
 /**
  * Middleware function type that represent a function that runs before the route handler
  * defined in the `createEndpoint/createEndpointConfig` function or globally in the `createRouter` function.
  */
-export type MiddlewareFunction<
-  RouteParams = Record<string, string>,
-  Config extends EndpointConfig = EndpointConfig,
-> = (
-  request: Request,
-  ctx: Prettify<RequestContext<RouteParams, Config>>,
-) => Promise<RequestContext<RouteParams, Config>>;
+export type MiddlewareFunction<RouteParams = Record<string, string>, Config extends EndpointConfig = EndpointConfig> = (
+    request: Request,
+    ctx: Prettify<RequestContext<RouteParams, Config>>
+) => Promise<RequestContext<RouteParams, Config>>
 
 /**
  * Configuration for an endpoint, including optional schemas for request validation and middlewares.
  */
 export type EndpointConfig<
-  RouteParams extends RoutePattern = RoutePattern,
-  Schemas extends EndpointSchemas = EndpointSchemas,
+    RouteParams extends RoutePattern = RoutePattern,
+    Schemas extends EndpointSchemas = EndpointSchemas,
 > = Prettify<{
-  schemas?: Schemas;
-  middlewares?: MiddlewareFunction<
-    GetRouteParams<RouteParams>,
-    { schemas: Schemas }
-  >[];
-}>;
+    schemas?: Schemas
+    middlewares?: MiddlewareFunction<GetRouteParams<RouteParams>, { schemas: Schemas }>[]
+}>
 
 /**
  * Infer the type of search parameters from the provided value in the `EndpointConfig`.
  */
-export type ContextSearchParams<Schemas extends EndpointConfig["schemas"]> =
-  Schemas extends { searchParams: ZodObject }
+export type ContextSearchParams<Schemas extends EndpointConfig["schemas"]> = Schemas extends { searchParams: ZodObject }
     ? { searchParams: z.infer<Schemas["searchParams"]> }
-    : { searchParams: URLSearchParams };
+    : { searchParams: URLSearchParams }
 
 /**
  * Infer the type of body from the provided value in the `EndpointConfig`.
  */
-export type ContextBody<Schemas extends EndpointConfig["schemas"]> =
-  Schemas extends { body: ZodObject }
+export type ContextBody<Schemas extends EndpointConfig["schemas"]> = Schemas extends { body: ZodObject }
     ? { body: z.infer<Schemas["body"]> }
-    : { body: undefined };
+    : { body: undefined }
 
 /**
  * Context object passed to route handlers and middlewares defined in the
  * `createEndpoint/createEndpointConfig` function or globally in the `createRouter` function.
  */
-export interface RequestContext<
-  RouteParams = Record<string, string>,
-  Config extends EndpointConfig = EndpointConfig,
-> {
-  params: RouteParams;
-  headers: Headers;
-  body: ContextBody<Config["schemas"]>["body"];
-  searchParams: ContextSearchParams<Config["schemas"]>["searchParams"];
+export interface RequestContext<RouteParams = Record<string, string>, Config extends EndpointConfig = EndpointConfig> {
+    params: RouteParams
+    headers: Headers
+    body: ContextBody<Config["schemas"]>["body"]
+    searchParams: ContextSearchParams<Config["schemas"]>["searchParams"]
 }
 
 /**
@@ -135,42 +118,35 @@ export interface RequestContext<
  * The handler receives the request object and a context containing route parameters, headers,
  * and optionally validated body and search parameters based on the endpoint configuration.
  */
-export type RouteHandler<
-  Route extends RoutePattern,
-  Config extends EndpointConfig,
-> = (
-  request: Request,
-  ctx: Prettify<RequestContext<GetRouteParams<Route>, Config>>,
-) => Promise<Response>;
+export type RouteHandler<Route extends RoutePattern, Config extends EndpointConfig> = (
+    request: Request,
+    ctx: Prettify<RequestContext<GetRouteParams<Route>, Config>>
+) => Promise<Response>
 
 /**
  * Represents a route endpoint definition, specifying the HTTP method, route pattern,
  * handler function with inferred context types, and associated configuration.
  */
 export interface RouteEndpoint<
-  Method extends HTTPMethod = HTTPMethod,
-  Route extends RoutePattern = RoutePattern,
-  Config extends EndpointConfig = EndpointConfig,
+    Method extends HTTPMethod = HTTPMethod,
+    Route extends RoutePattern = RoutePattern,
+    Config extends EndpointConfig = EndpointConfig,
 > {
-  method: Method;
-  route: Route;
-  handler: RouteHandler<Route, Config>;
-  config: Config;
+    method: Method
+    route: Route
+    handler: RouteHandler<Route, Config>
+    config: Config
 }
 
 /**
  * Infer the HTTP methods defined in the provided array of route endpoints.
  */
-export type InferMethod<Endpoints extends RouteEndpoint[]> =
-  Endpoints extends unknown[] ? Endpoints[number]["method"] : "unknown";
+export type InferMethod<Endpoints extends RouteEndpoint[]> = Endpoints extends unknown[] ? Endpoints[number]["method"] : "unknown"
 
 /**
  * Generates an object with HTTP methods available by the router from `createRouter` function.
  * Each method is a function that takes a request and context, returning a promise of a response.
  */
 export type GetHttpHandlers<Endpoints extends RouteEndpoint[]> = {
-  [Method in InferMethod<Endpoints>]: (
-    req: Request,
-    ctx: RequestContext,
-  ) => Promise<Response>;
-};
+    [Method in InferMethod<Endpoints>]: (req: Request, ctx: RequestContext) => Promise<Response>
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,14 +18,6 @@ export type HTTPMethod = "GET" | "POST" | "DELETE" | "PUT" | "PATCH"
  */
 export type ContentType = "application/json" | "application/x-www-form-urlencoded" | "text/plain"
 
-/**
- * Configuration options for `createRouter` function.
- */
-export interface RouterConfig {
-    basePath?: RoutePattern
-    middlewares?: GlobalMiddleware[]
-}
-
 export type Prettify<Obj extends object> = {
     [Key in keyof Obj]: Obj[Key]
 } & {}
@@ -64,20 +56,6 @@ export interface EndpointSchemas {
 }
 
 /**
- * Global middleware function type that represent a function that runs before the route matching.
- */
-export type GlobalMiddleware = (request: Request) => Promise<Request | Response>
-
-/**
- * Middleware function type that represent a function that runs before the route handler
- * defined in the `createEndpoint/createEndpointConfig` function or globally in the `createRouter` function.
- */
-export type MiddlewareFunction<RouteParams = Record<string, string>, Config extends EndpointConfig = EndpointConfig> = (
-    request: Request,
-    ctx: Prettify<RequestContext<RouteParams, Config>>
-) => Promise<RequestContext<RouteParams, Config>>
-
-/**
  * Configuration for an endpoint, including optional schemas for request validation and middlewares.
  */
 export type EndpointConfig<
@@ -112,6 +90,20 @@ export interface RequestContext<RouteParams = Record<string, string>, Config ext
     body: ContextBody<Config["schemas"]>["body"]
     searchParams: ContextSearchParams<Config["schemas"]>["searchParams"]
 }
+
+/**
+ * Global middleware function type that represent a function that runs before the route matching.
+ */
+export type GlobalMiddleware = (request: Request) => Promise<Request | Response>
+
+/**
+ * Middleware function type that represent a function that runs before the route handler
+ * defined in the `createEndpoint/createEndpointConfig` function or globally in the `createRouter` function.
+ */
+export type MiddlewareFunction<RouteParams = Record<string, string>, Config extends EndpointConfig = EndpointConfig> = (
+    request: Request,
+    ctx: Prettify<RequestContext<RouteParams, Config>>
+) => Promise<RequestContext<RouteParams, Config>>
 
 /**
  * Defines a route handler function that processes an incoming request and returns a response.
@@ -149,4 +141,12 @@ export type InferMethod<Endpoints extends RouteEndpoint[]> = Endpoints extends u
  */
 export type GetHttpHandlers<Endpoints extends RouteEndpoint[]> = {
     [Method in InferMethod<Endpoints>]: (req: Request, ctx: RequestContext) => Promise<Response>
+}
+
+/**
+ * Configuration options for `createRouter` function.
+ */
+export interface RouterConfig {
+    basePath?: RoutePattern
+    middlewares?: GlobalMiddleware[]
 }

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,507 +1,487 @@
-import z from "zod";
-import { describe, expectTypeOf, test } from "vitest";
-import {
-  getRouteParams,
-  getSearchParams,
-  getHeaders,
-  getBody,
-} from "../src/context.js";
-import type { RoutePattern } from "../src/types.js";
+import z from "zod"
+import { describe, expectTypeOf, test } from "vitest"
+import { getRouteParams, getSearchParams, getHeaders, getBody } from "../src/context.js"
+import type { RoutePattern } from "../src/types.js"
 
 describe("getRouteParams", () => {
-  const testCases = [
-    {
-      description: "Empty route and path",
-      route: "",
-      path: "",
-      expected: {},
-    },
-    {
-      description: "Extracts only userId from the path",
-      route: "/users/:userId/books",
-      path: "/users/123/books",
-      expected: {
-        userId: "123",
-      },
-    },
-    {
-      description: "Extracts userId and bookId from the path",
-      route: "/users/:userId/books/:bookId",
-      path: "/users/123/books/456",
-      expected: {
-        userId: "123",
-        bookId: "456",
-      },
-    },
-    {
-      description: "No parameters in the route",
-      route: "/about",
-      path: "/about",
-      expected: {},
-    },
-    {
-      description: "Mismatched route and path",
-      route: "/users/:userId/books",
-      path: "/users/123/books/456",
-      expected: {},
-    },
-    {
-      description: "Mismatched with path with extra segments",
-      route: "/users/:userId",
-      path: "/users/123/books",
-      expected: {},
-    },
-    {
-      description: "Mismatched with path with missing segments",
-      route: "/users/:userId/books/:bookId",
-      path: "/users/123/books",
-      expected: {},
-    },
-    {
-      description: "Parameters with special characters",
-      route: "/search/:query",
-      path: "/search/hello%20world",
-      expected: {
-        query: "hello world",
-      },
-    },
-  ];
+    const testCases = [
+        {
+            description: "Empty route and path",
+            route: "",
+            path: "",
+            expected: {},
+        },
+        {
+            description: "Extracts only userId from the path",
+            route: "/users/:userId/books",
+            path: "/users/123/books",
+            expected: {
+                userId: "123",
+            },
+        },
+        {
+            description: "Extracts userId and bookId from the path",
+            route: "/users/:userId/books/:bookId",
+            path: "/users/123/books/456",
+            expected: {
+                userId: "123",
+                bookId: "456",
+            },
+        },
+        {
+            description: "No parameters in the route",
+            route: "/about",
+            path: "/about",
+            expected: {},
+        },
+        {
+            description: "Mismatched route and path",
+            route: "/users/:userId/books",
+            path: "/users/123/books/456",
+            expected: {},
+        },
+        {
+            description: "Mismatched with path with extra segments",
+            route: "/users/:userId",
+            path: "/users/123/books",
+            expected: {},
+        },
+        {
+            description: "Mismatched with path with missing segments",
+            route: "/users/:userId/books/:bookId",
+            path: "/users/123/books",
+            expected: {},
+        },
+        {
+            description: "Parameters with special characters",
+            route: "/search/:query",
+            path: "/search/hello%20world",
+            expected: {
+                query: "hello world",
+            },
+        },
+    ]
 
-  testCases.forEach(({ description, route, path, expected }) => {
-    test.concurrent(description, ({ expect }) => {
-      expect(getRouteParams(route as RoutePattern, path)).toEqual(expected);
-    });
-  });
-});
+    testCases.forEach(({ description, route, path, expected }) => {
+        test.concurrent(description, ({ expect }) => {
+            expect(getRouteParams(route as RoutePattern, path)).toEqual(expected)
+        })
+    })
+})
 
 describe("getSearchParams", () => {
-  describe("Without schema validation", () => {
-    const testCases = [
-      {
-        description: "No search parameters",
-        url: "http://example.com",
-        config: {},
-        expected: {},
-      },
-      {
-        description: "Single search parameter",
-        url: "http://example.com?name=John",
-        config: {},
-        expected: { name: "John" },
-      },
-      {
-        description: "Multiple search parameters",
-        url: "http://example.com?name=John&age=30",
-        config: {},
-        expected: { name: "John", age: "30" },
-      },
-      {
-        description: "Encoded search parameters",
-        url: "http://example.com?query=hello%20world",
-        config: {},
-        expected: { query: "hello world" },
-      },
-    ];
-
-    testCases.forEach(({ description, url, config, expected }) => {
-      test.concurrent(description, ({ expect }) => {
-        const searchParams = getSearchParams(url, config);
-        expect(searchParams instanceof URLSearchParams).toBe(true);
-        expect(searchParams).toBeDefined();
-        expect(searchParams).toBeInstanceOf(URLSearchParams);
-        expect(searchParams).toEqual(
-          new URLSearchParams(expected as Record<string, string>),
-        );
-        expect(searchParams).not.toEqual(expected);
-      });
-    });
-
-    test("Check return type is URLSearchParams", () => {
-      const withoutParams = {
-        url: "http://example.com",
-        config: { schemas: {} },
-      };
-      expectTypeOf(
-        getSearchParams(withoutParams.url, withoutParams.config),
-      ).toEqualTypeOf<URLSearchParams>();
-    });
-  });
-
-  describe("With schema validation", () => {
-    const testCases = [
-      {
-        description: "No search parameters",
-        url: "http://example.com",
-        config: {
-          schemas: {
-            searchParams: z.object({}),
-          },
-        },
-        expected: {},
-      },
-      {
-        description: "Single search parameter",
-        url: "http://example.com?name=John",
-        config: {
-          schemas: {
-            searchParams: z.object({
-              name: z.string(),
-            }),
-          },
-        },
-        expected: {
-          name: "John",
-        },
-      },
-      {
-        description: "Multiple search parameters",
-        url: "http://example.com?name=John&age=30",
-        config: {
-          schemas: {
-            searchParams: z.object({
-              name: z.string(),
-              age: z.string(),
-            }),
-          },
-        },
-        expected: {
-          name: "John",
-          age: "30",
-        },
-      },
-      {
-        description: "Encoded search parameters",
-        url: "http://example.com?query=hello%20world",
-        config: {
-          schemas: {
-            searchParams: z.object({
-              query: z.string(),
-            }),
-          },
-        },
-        expected: {
-          query: "hello world",
-        },
-      },
-      {
-        description: "Extra unexpected search parameter",
-        url: "http://example.com?name=John&age=30",
-        config: {
-          schemas: {
-            searchParams: z.object({
-              name: z.string(),
-            }),
-          },
-        },
-        expected: {
-          name: "John",
-        },
-      },
-      {
-        description: "Without schema definition",
-        url: "http://example.com?name=John",
-        config: {
-          schemas: {
-            searchParams: z.object({}),
-          },
-        },
-        expected: {},
-      },
-    ];
-    testCases.forEach(({ description, url, config, expected }) => {
-      test.concurrent(description, ({ expect }) => {
-        const searchParams = getSearchParams(url, config);
-        expect(searchParams instanceof Object).toBe(true);
-        expect(searchParams).toBeDefined();
-        expect(searchParams).toBeInstanceOf(Object);
-        expect(searchParams).toEqual(expected);
-        expect(searchParams).not.toBeInstanceOf(URLSearchParams);
-      });
-    });
-  });
-
-  describe("With invalid parameters", () => {
-    const testCases = [
-      {
-        description: "Invalid search parameters",
-        url: "http://example.com?age=thirty",
-        config: {
-          schemas: {
-            searchParams: z.object({
-              age: z.number(),
-            }),
-          },
-        },
-        expected: /Invalid search parameters/,
-      },
-      {
-        description: "Missing required search parameter",
-        url: "http://example.com",
-        config: {
-          schemas: {
-            searchParams: z.object({
-              name: z.string(),
-            }),
-          },
-        },
-        expected: /Invalid search parameters/,
-      },
-      {
-        description: "Invalid type for search parameter",
-        url: "http://example.com?isAdmin=notABoolean",
-        config: {
-          schemas: {
-            searchParams: z.object({
-              isAdmin: z.boolean(),
-            }),
-          },
-        },
-        expected: /Invalid search parameters*/,
-      },
-    ];
-
-    testCases.forEach(({ description, url, config, expected }) => {
-      test.concurrent(description, ({ expect }) => {
-        expect(() => getSearchParams(url, config)).toThrowError(expected);
-      });
-    });
-
-    describe("Check return type is Object", () => {
-      test("No search params", () => {
-        const withoutParams = {
-          url: "http://example.com?name=John",
-          config: {
-            schemas: {
-              searchParams: z.object({
-                name: z.string(),
-              }),
+    describe("Without schema validation", () => {
+        const testCases = [
+            {
+                description: "No search parameters",
+                url: "http://example.com",
+                config: {},
+                expected: {},
             },
-          },
-        };
-        expectTypeOf(
-          getSearchParams(withoutParams.url, withoutParams.config),
-        ).toEqualTypeOf<{
-          name: string;
-        }>();
-      });
-
-      test("No search params", () => {
-        const withParams = {
-          url: "http://example.com?name=John",
-          config: {
-            schemas: {
-              searchParams: z.object({
-                name: z.string(),
-              }),
+            {
+                description: "Single search parameter",
+                url: "http://example.com?name=John",
+                config: {},
+                expected: { name: "John" },
             },
-          },
-        };
-        expectTypeOf(
-          getSearchParams(withParams.url, withParams.config),
-        ).toEqualTypeOf<{
-          name: string;
-        }>();
-      });
-
-      test("Without schema definition", () => {
-        const withoutSchema = {
-          url: "http://example.com?name=John",
-          config: {
-            schemas: {
-              searchParams: z.object({}),
+            {
+                description: "Multiple search parameters",
+                url: "http://example.com?name=John&age=30",
+                config: {},
+                expected: { name: "John", age: "30" },
             },
-          },
-        };
-        expectTypeOf(
-          getSearchParams(withoutSchema.url, withoutSchema.config),
-        ).not.toEqualTypeOf<URLSearchParams>();
-        expectTypeOf(
-          getSearchParams(withoutSchema.url, withoutSchema.config),
-        ).toEqualTypeOf<Record<string, never>>();
-      });
-    });
-  });
+            {
+                description: "Encoded search parameters",
+                url: "http://example.com?query=hello%20world",
+                config: {},
+                expected: { query: "hello world" },
+            },
+        ]
 
-  describe("Infer types", () => {
-    test("Infer types from zod schema", () => {
-      const config = {
-        schemas: {
-          searchParams: z.object({
-            name: z.string(),
-          }),
-        },
-      };
-      const searchParams = getSearchParams(
-        "http://example.com?name=John",
-        config,
-      );
-      expectTypeOf(searchParams).toEqualTypeOf<{ name: string }>();
-      expectTypeOf(searchParams.name).toBeString();
-    });
-  });
-});
+        testCases.forEach(({ description, url, config, expected }) => {
+            test.concurrent(description, ({ expect }) => {
+                const searchParams = getSearchParams(url, config)
+                expect(searchParams instanceof URLSearchParams).toBe(true)
+                expect(searchParams).toBeDefined()
+                expect(searchParams).toBeInstanceOf(URLSearchParams)
+                expect(searchParams).toEqual(new URLSearchParams(expected as Record<string, string>))
+                expect(searchParams).not.toEqual(expected)
+            })
+        })
+
+        test("Check return type is URLSearchParams", () => {
+            const withoutParams = {
+                url: "http://example.com",
+                config: { schemas: {} },
+            }
+            expectTypeOf(getSearchParams(withoutParams.url, withoutParams.config)).toEqualTypeOf<URLSearchParams>()
+        })
+    })
+
+    describe("With schema validation", () => {
+        const testCases = [
+            {
+                description: "No search parameters",
+                url: "http://example.com",
+                config: {
+                    schemas: {
+                        searchParams: z.object({}),
+                    },
+                },
+                expected: {},
+            },
+            {
+                description: "Single search parameter",
+                url: "http://example.com?name=John",
+                config: {
+                    schemas: {
+                        searchParams: z.object({
+                            name: z.string(),
+                        }),
+                    },
+                },
+                expected: {
+                    name: "John",
+                },
+            },
+            {
+                description: "Multiple search parameters",
+                url: "http://example.com?name=John&age=30",
+                config: {
+                    schemas: {
+                        searchParams: z.object({
+                            name: z.string(),
+                            age: z.string(),
+                        }),
+                    },
+                },
+                expected: {
+                    name: "John",
+                    age: "30",
+                },
+            },
+            {
+                description: "Encoded search parameters",
+                url: "http://example.com?query=hello%20world",
+                config: {
+                    schemas: {
+                        searchParams: z.object({
+                            query: z.string(),
+                        }),
+                    },
+                },
+                expected: {
+                    query: "hello world",
+                },
+            },
+            {
+                description: "Extra unexpected search parameter",
+                url: "http://example.com?name=John&age=30",
+                config: {
+                    schemas: {
+                        searchParams: z.object({
+                            name: z.string(),
+                        }),
+                    },
+                },
+                expected: {
+                    name: "John",
+                },
+            },
+            {
+                description: "Without schema definition",
+                url: "http://example.com?name=John",
+                config: {
+                    schemas: {
+                        searchParams: z.object({}),
+                    },
+                },
+                expected: {},
+            },
+        ]
+        testCases.forEach(({ description, url, config, expected }) => {
+            test.concurrent(description, ({ expect }) => {
+                const searchParams = getSearchParams(url, config)
+                expect(searchParams instanceof Object).toBe(true)
+                expect(searchParams).toBeDefined()
+                expect(searchParams).toBeInstanceOf(Object)
+                expect(searchParams).toEqual(expected)
+                expect(searchParams).not.toBeInstanceOf(URLSearchParams)
+            })
+        })
+    })
+
+    describe("With invalid parameters", () => {
+        const testCases = [
+            {
+                description: "Invalid search parameters",
+                url: "http://example.com?age=thirty",
+                config: {
+                    schemas: {
+                        searchParams: z.object({
+                            age: z.number(),
+                        }),
+                    },
+                },
+                expected: /Invalid search parameters/,
+            },
+            {
+                description: "Missing required search parameter",
+                url: "http://example.com",
+                config: {
+                    schemas: {
+                        searchParams: z.object({
+                            name: z.string(),
+                        }),
+                    },
+                },
+                expected: /Invalid search parameters/,
+            },
+            {
+                description: "Invalid type for search parameter",
+                url: "http://example.com?isAdmin=notABoolean",
+                config: {
+                    schemas: {
+                        searchParams: z.object({
+                            isAdmin: z.boolean(),
+                        }),
+                    },
+                },
+                expected: /Invalid search parameters*/,
+            },
+        ]
+
+        testCases.forEach(({ description, url, config, expected }) => {
+            test.concurrent(description, ({ expect }) => {
+                expect(() => getSearchParams(url, config)).toThrowError(expected)
+            })
+        })
+
+        describe("Check return type is Object", () => {
+            test("No search params", () => {
+                const withoutParams = {
+                    url: "http://example.com?name=John",
+                    config: {
+                        schemas: {
+                            searchParams: z.object({
+                                name: z.string(),
+                            }),
+                        },
+                    },
+                }
+                expectTypeOf(getSearchParams(withoutParams.url, withoutParams.config)).toEqualTypeOf<{
+                    name: string
+                }>()
+            })
+
+            test("No search params", () => {
+                const withParams = {
+                    url: "http://example.com?name=John",
+                    config: {
+                        schemas: {
+                            searchParams: z.object({
+                                name: z.string(),
+                            }),
+                        },
+                    },
+                }
+                expectTypeOf(getSearchParams(withParams.url, withParams.config)).toEqualTypeOf<{
+                    name: string
+                }>()
+            })
+
+            test("Without schema definition", () => {
+                const withoutSchema = {
+                    url: "http://example.com?name=John",
+                    config: {
+                        schemas: {
+                            searchParams: z.object({}),
+                        },
+                    },
+                }
+                expectTypeOf(getSearchParams(withoutSchema.url, withoutSchema.config)).not.toEqualTypeOf<URLSearchParams>()
+                expectTypeOf(getSearchParams(withoutSchema.url, withoutSchema.config)).toEqualTypeOf<Record<string, never>>()
+            })
+        })
+    })
+
+    describe("Infer types", () => {
+        test("Infer types from zod schema", () => {
+            const config = {
+                schemas: {
+                    searchParams: z.object({
+                        name: z.string(),
+                    }),
+                },
+            }
+            const searchParams = getSearchParams("http://example.com?name=John", config)
+            expectTypeOf(searchParams).toEqualTypeOf<{ name: string }>()
+            expectTypeOf(searchParams.name).toBeString()
+        })
+    })
+})
 
 describe("getHeaders", () => {
-  const testCases = [
-    {
-      description: "No headers",
-      request: new Request("http://example.com"),
-      expected: new Headers({}),
-    },
-    {
-      description: "Single header",
-      request: new Request("http://example.com", {
-        headers: { Authorization: "Bearer token" },
-      }),
-      expected: new Headers({ Authorization: "Bearer token" }),
-    },
-    {
-      description: "Multiple headers",
-      request: new Request("http://example.com", {
-        headers: {
-          "Content-Type": "application/json",
-          Accept: "application/json",
+    const testCases = [
+        {
+            description: "No headers",
+            request: new Request("http://example.com"),
+            expected: new Headers({}),
         },
-      }),
-      expected: new Headers({
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      }),
-    },
-  ];
-  testCases.forEach(({ description, request, expected }) => {
-    test.concurrent(description, ({ expect }) => {
-      const headers = getHeaders(request);
-      expect(headers instanceof Headers).toBe(true);
-      expect(headers).toBeDefined();
-      expect(headers).toBeInstanceOf(Headers);
-      expect(headers).toEqual(expected);
-    });
-  });
-});
+        {
+            description: "Single header",
+            request: new Request("http://example.com", {
+                headers: { Authorization: "Bearer token" },
+            }),
+            expected: new Headers({ Authorization: "Bearer token" }),
+        },
+        {
+            description: "Multiple headers",
+            request: new Request("http://example.com", {
+                headers: {
+                    "Content-Type": "application/json",
+                    Accept: "application/json",
+                },
+            }),
+            expected: new Headers({
+                "Content-Type": "application/json",
+                Accept: "application/json",
+            }),
+        },
+    ]
+    testCases.forEach(({ description, request, expected }) => {
+        test.concurrent(description, ({ expect }) => {
+            const headers = getHeaders(request)
+            expect(headers instanceof Headers).toBe(true)
+            expect(headers).toBeDefined()
+            expect(headers).toBeInstanceOf(Headers)
+            expect(headers).toEqual(expected)
+        })
+    })
+})
 
 describe("getBody", () => {
-  describe("Valid body", () => {
-    const testCases = [
-      {
-        description: "Text body",
-        request: new Request("http://example.com/echo", {
-          method: "POST",
-          headers: { "Content-Type": "text/plain" },
-          body: "Hello, World!",
-        }),
-        config: {},
-        expected: "Hello, World!",
-      },
-      {
-        description: "JSON body with content-type missing",
-        request: new Request("http://example.com/auth/credentials", {
-          method: "POST",
-          body: JSON.stringify({
-            username: "John",
-            password: "secret",
-          }),
-        }),
-        config: {},
-        expected: JSON.stringify({
-          username: "John",
-          password: "secret",
-        }),
-      },
-      {
-        description: "JSON body without schema",
-        request: new Request("http://example.com/auth/credentials", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            username: "John",
-            password: "secret",
-          }),
-        }),
-        config: {},
-        expected: {
-          username: "John",
-          password: "secret",
-        },
-      },
-      {
-        description: "JSON body with schema",
-        request: new Request("http://example.com/auth/credentials", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            username: "John",
-            password: "secret",
-          }),
-        }),
-        config: {
-          schemas: {
-            body: z.object({
-              username: z.string(),
-              password: z.string(),
-            }),
-          },
-        },
-        expected: { username: "John", password: "secret" },
-      },
-    ];
+    describe("Valid body", () => {
+        const testCases = [
+            {
+                description: "Text body",
+                request: new Request("http://example.com/echo", {
+                    method: "POST",
+                    headers: { "Content-Type": "text/plain" },
+                    body: "Hello, World!",
+                }),
+                config: {},
+                expected: "Hello, World!",
+            },
+            {
+                description: "JSON body with content-type missing",
+                request: new Request("http://example.com/auth/credentials", {
+                    method: "POST",
+                    body: JSON.stringify({
+                        username: "John",
+                        password: "secret",
+                    }),
+                }),
+                config: {},
+                expected: JSON.stringify({
+                    username: "John",
+                    password: "secret",
+                }),
+            },
+            {
+                description: "JSON body without schema",
+                request: new Request("http://example.com/auth/credentials", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                        username: "John",
+                        password: "secret",
+                    }),
+                }),
+                config: {},
+                expected: {
+                    username: "John",
+                    password: "secret",
+                },
+            },
+            {
+                description: "JSON body with schema",
+                request: new Request("http://example.com/auth/credentials", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                        username: "John",
+                        password: "secret",
+                    }),
+                }),
+                config: {
+                    schemas: {
+                        body: z.object({
+                            username: z.string(),
+                            password: z.string(),
+                        }),
+                    },
+                },
+                expected: { username: "John", password: "secret" },
+            },
+        ]
 
-    testCases.forEach(({ description, request, config, expected }) => {
-      test.concurrent(description, async ({ expect }) => {
-        const body = await getBody(request, config);
-        expect(body).toBeDefined();
-        expect(body).toEqual(expected);
-      });
-    });
-  });
+        testCases.forEach(({ description, request, config, expected }) => {
+            test.concurrent(description, async ({ expect }) => {
+                const body = await getBody(request, config)
+                expect(body).toBeDefined()
+                expect(body).toEqual(expected)
+            })
+        })
+    })
 
-  describe("Invalid body", () => {
-    const testCases = [
-      {
-        description: "Invalid JSON body with schema",
-        request: new Request("http://example.com/auth/credentials", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            username: "John",
-            password: 123,
-          }),
-        }),
-        config: {
-          schemas: {
-            body: z.object({
-              username: z.string(),
-              password: z.string(),
-            }),
-          },
-        },
-        expected: /Invalid request body/,
-      },
-      {
-        description: "Invalid JSON body missing required field",
-        request: new Request("http://example.com/auth/credentials", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            username: "John",
-          }),
-        }),
-        config: {
-          schemas: {
-            body: z.object({
-              username: z.string(),
-              password: z.string(),
-            }),
-          },
-        },
-        expected: /Invalid request body/,
-      },
-    ];
+    describe("Invalid body", () => {
+        const testCases = [
+            {
+                description: "Invalid JSON body with schema",
+                request: new Request("http://example.com/auth/credentials", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                        username: "John",
+                        password: 123,
+                    }),
+                }),
+                config: {
+                    schemas: {
+                        body: z.object({
+                            username: z.string(),
+                            password: z.string(),
+                        }),
+                    },
+                },
+                expected: /Invalid request body/,
+            },
+            {
+                description: "Invalid JSON body missing required field",
+                request: new Request("http://example.com/auth/credentials", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                        username: "John",
+                    }),
+                }),
+                config: {
+                    schemas: {
+                        body: z.object({
+                            username: z.string(),
+                            password: z.string(),
+                        }),
+                    },
+                },
+                expected: /Invalid request body/,
+            },
+        ]
 
-    testCases.forEach(({ description, request, config, expected }) => {
-      test.concurrent(description, async ({ expect }) => {
-        await expect(getBody(request, config)).rejects.toThrowError(expected);
-      });
-    });
-  });
-});
+        testCases.forEach(({ description, request, config, expected }) => {
+            test.concurrent(description, async ({ expect }) => {
+                await expect(getBody(request, config)).rejects.toThrowError(expected)
+            })
+        })
+    })
+})

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -1,394 +1,365 @@
-import z from "zod";
-import { describe, test } from "vitest";
-import { createRouter } from "../src/router.js";
-import { createEndpoint, createRoutePattern } from "../src/endpoint.js";
-import type { HTTPMethod, RoutePattern, RequestContext } from "../src/types.js";
+import z from "zod"
+import { describe, test } from "vitest"
+import { createRouter } from "../src/router.js"
+import { createEndpoint, createRoutePattern } from "../src/endpoint.js"
+import type { HTTPMethod, RoutePattern, RequestContext } from "../src/types.js"
 
 describe("createRoutePattern", () => {
-  const testCases = [
-    {
-      description: "Converts route without parameters to regex",
-      route: "/about",
-      expected: /^\/about$/,
-    },
-    {
-      description: "Converts root route to regex",
-      route: "/",
-      expected: /^\/$/,
-    },
-    {
-      description: "Converts route with one parameter to regex",
-      route: "/users/:userId/books",
-      expected: /^\/users\/([^\/]+)\/books$/,
-    },
-    {
-      description: "Converts route with two parameters to regex",
-      route: "/users/:userId/books/:bookId",
-      expected: /^\/users\/([^\/]+)\/books\/([^\/]+)$/,
-    },
-  ];
-  testCases.forEach(({ description, route, expected }) => {
-    test.concurrent(description, ({ expect }) => {
-      const regex = createRoutePattern(route as RoutePattern);
-      expect(regex).toEqual(expected);
-    });
-  });
-});
+    const testCases = [
+        {
+            description: "Converts route without parameters to regex",
+            route: "/about",
+            expected: /^\/about$/,
+        },
+        {
+            description: "Converts root route to regex",
+            route: "/",
+            expected: /^\/$/,
+        },
+        {
+            description: "Converts route with one parameter to regex",
+            route: "/users/:userId/books",
+            expected: /^\/users\/([^\/]+)\/books$/,
+        },
+        {
+            description: "Converts route with two parameters to regex",
+            route: "/users/:userId/books/:bookId",
+            expected: /^\/users\/([^\/]+)\/books\/([^\/]+)$/,
+        },
+    ]
+    testCases.forEach(({ description, route, expected }) => {
+        test.concurrent(description, ({ expect }) => {
+            const regex = createRoutePattern(route as RoutePattern)
+            expect(regex).toEqual(expected)
+        })
+    })
+})
 
 describe("createEndpoint", () => {
-  describe("With valid configuration", () => {
-    const testCases = [
-      {
-        description: "Create GET endpoint with route",
-        method: "GET",
-        route: "/users/:userId",
-        expected: {
-          method: "GET",
-          route: "/users/:userId",
-          config: {},
-        },
-      },
-      {
-        description: "Create POST endpoint with route",
-        method: "POST",
-        route: "/users",
-        expected: {
-          method: "POST",
-          route: "/users",
-          config: {},
-        },
-      },
-      {
-        description: "Create DELETE endpoint with route",
-        method: "DELETE",
-        route: "/users/:userId",
-        expected: {
-          method: "DELETE",
-          route: "/users/:userId",
-          config: {},
-        },
-      },
-    ];
-
-    testCases.forEach(({ description, method, route, expected }) => {
-      test.concurrent(description, ({ expect }) => {
-        const handler: any = () => {};
-        const endpoint = createEndpoint(
-          method as HTTPMethod,
-          route as Lowercase<RoutePattern>,
-          handler,
-        );
-        expect(endpoint).toEqual({ ...expected, handler });
-      });
-    });
-  });
-
-  describe("With invalid configuration", () => {
-    const testCases = [
-      {
-        description: "Throws error for unsupported HTTP method",
-        method: "FETCH",
-        route: "/users",
-        expected: /Unsupported HTTP method: FETCH/,
-      },
-    ];
-
-    testCases.forEach(({ description, method, route, expected }) => {
-      test.concurrent(description, ({ expect }) => {
-        const handler: any = () => {};
-        expect(() =>
-          createEndpoint(
-            method as HTTPMethod,
-            route as Lowercase<RoutePattern>,
-            handler,
-            {},
-          ),
-        ).toThrowError(expected);
-      });
-    });
-  });
-
-  describe("With schemas", () => {
-    describe("With body schema", () => {
-      const endpoint = createEndpoint(
-        "POST",
-        "/auth/credentials",
-        async (_, ctx) => {
-          return Response.json({ body: ctx.body });
-        },
-        {
-          schemas: {
-            body: z.object({
-              username: z.string(),
-              password: z.string(),
-            }),
-          },
-        },
-      );
-      const { POST } = createRouter([endpoint]);
-
-      test("With valid body", async ({ expect }) => {
-        const post = await POST(
-          new Request("https://example.com/auth/credentials", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ username: "John", password: "secret" }),
-          }),
-          {} as RequestContext,
-        );
-        expect(post.ok).toBe(true);
-        expect(await post.json()).toEqual({
-          body: { username: "John", password: "secret" },
-        });
-      });
-
-      test("With invalid body", async ({ expect }) => {
-        await expect(
-          POST(
-            new Request("https://example.com/auth/credentials", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ username: "John" }),
-            }),
-            {} as RequestContext,
-          ),
-        ).rejects.toThrowError(/Invalid request body/);
-      });
-    });
-
-    describe("With searchParams schema", () => {
-      const endpoint = createEndpoint(
-        "GET",
-        "/auth/:oauth",
-        async (_, ctx) => {
-          return Response.json({ searchParams: ctx.searchParams });
-        },
-        {
-          schemas: {
-            searchParams: z.object({
-              state: z.string(),
-              code: z.string(),
-            }),
-          },
-        },
-      );
-      const { GET } = createRouter([endpoint]);
-
-      test("With valid searchParams", async ({ expect }) => {
-        const get = await GET(
-          new Request("https://example.com/auth/google?state=123abc&code=123"),
-          {} as RequestContext,
-        );
-        expect(get.ok).toBe(true);
-        expect(await get.json()).toEqual({
-          searchParams: { state: "123abc", code: "123" },
-        });
-      });
-
-      test("With invalid searchParams", async ({ expect }) => {
-        await expect(
-          GET(
-            new Request("https://example.com/auth/google?state=123abc"),
-            {} as RequestContext,
-          ),
-        ).rejects.toThrowError(/Invalid search parameters/);
-      });
-    });
-  });
-
-  describe("With middlewares", () => {
-    test("Update params context in middleware", async ({ expect }) => {
-      const endpoint = createEndpoint(
-        "GET",
-        "/auth/:oauth",
-        async (_, ctx) => {
-          const oauth = ctx.params.oauth;
-          return Response.json({ oauth });
-        },
-        {
-          middlewares: [
-            async (_, ctx) => {
-              ctx.params = { oauth: "google" };
-              return ctx;
+    describe("With valid configuration", () => {
+        const testCases = [
+            {
+                description: "Create GET endpoint with route",
+                method: "GET",
+                route: "/users/:userId",
+                expected: {
+                    method: "GET",
+                    route: "/users/:userId",
+                    config: {},
+                },
             },
-          ],
-        },
-      );
-      const { GET } = createRouter([endpoint]);
-      const get = await GET(
-        new Request("https://example.com/auth/github"),
-        {} as RequestContext,
-      );
-      expect(get.ok).toBe(true);
-      expect(await get.json()).toEqual({ oauth: "google" });
-    });
-
-    test("Update searchParams context in middleware", async ({ expect }) => {
-      const endpoint = createEndpoint(
-        "GET",
-        "/auth/google",
-        async (_, ctx) => {
-          const searchParams = Object.fromEntries(ctx.searchParams.entries());
-          return Response.json({ searchParams });
-        },
-        {
-          middlewares: [
-            async (_, ctx) => {
-              ctx.searchParams.set("state", "123abc");
-              ctx.searchParams.set("code", "123");
-              return ctx;
+            {
+                description: "Create POST endpoint with route",
+                method: "POST",
+                route: "/users",
+                expected: {
+                    method: "POST",
+                    route: "/users",
+                    config: {},
+                },
             },
-          ],
-        },
-      );
-      const { GET } = createRouter([endpoint]);
-      const get = await GET(
-        new Request("https://example.com/auth/google"),
-        {} as RequestContext,
-      );
-      expect(get.ok).toBe(true);
-      expect(await get.json()).toEqual({
-        searchParams: { state: "123abc", code: "123" },
-      });
-    });
-
-    test("Update headers context in middleware", async ({ expect }) => {
-      const endpoint = createEndpoint(
-        "GET",
-        "/headers",
-        async (_, ctx) => {
-          const headers = Object.fromEntries(ctx.headers.entries());
-          return Response.json({ headers });
-        },
-        {
-          middlewares: [
-            async (_, ctx) => {
-              ctx.headers.set("Authorization", "Bearer token");
-              return ctx;
+            {
+                description: "Create DELETE endpoint with route",
+                method: "DELETE",
+                route: "/users/:userId",
+                expected: {
+                    method: "DELETE",
+                    route: "/users/:userId",
+                    config: {},
+                },
             },
-          ],
-        },
-      );
-      const { GET } = createRouter([endpoint]);
-      const get = await GET(
-        new Request("https://example.com/headers"),
-        {} as RequestContext,
-      );
-      expect(get.ok).toBe(true);
-      expect(await get.json()).toEqual({
-        headers: { authorization: "Bearer token" },
-      });
-    });
-  });
+        ]
 
-  describe("With schemas and middlewares", () => {
-    test("Override body in middleware", async ({ expect }) => {
-      const endpoint = createEndpoint(
-        "POST",
-        "/auth/credentials",
-        async (_, ctx) => {
-          return Response.json({ body: ctx.body });
-        },
-        {
-          schemas: {
-            body: z.object({
-              username: z.string(),
-              password: z.string(),
-            }),
-          },
-          middlewares: [
-            async (_, ctx) => {
-              const body = ctx.body as any;
-              body.userId = 12;
-              return ctx;
+        testCases.forEach(({ description, method, route, expected }) => {
+            test.concurrent(description, ({ expect }) => {
+                const handler: any = () => {}
+                const endpoint = createEndpoint(method as HTTPMethod, route as Lowercase<RoutePattern>, handler)
+                expect(endpoint).toEqual({ ...expected, handler })
+            })
+        })
+    })
+
+    describe("With invalid configuration", () => {
+        const testCases = [
+            {
+                description: "Throws error for unsupported HTTP method",
+                method: "FETCH",
+                route: "/users",
+                expected: /Unsupported HTTP method: FETCH/,
             },
-          ],
-        },
-      );
-      const { POST } = createRouter([endpoint]);
+        ]
 
-      const post = await POST(
-        new Request("https://example.com/auth/credentials", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ username: "John", password: "secret" }),
-        }),
-        {} as RequestContext,
-      );
-      expect(post.ok).toBe(true);
-      expect(await post.json()).toEqual({
-        body: { username: "John", password: "secret", userId: 12 },
-      });
-    });
+        testCases.forEach(({ description, method, route, expected }) => {
+            test.concurrent(description, ({ expect }) => {
+                const handler: any = () => {}
+                expect(() => createEndpoint(method as HTTPMethod, route as Lowercase<RoutePattern>, handler, {})).toThrowError(
+                    expected
+                )
+            })
+        })
+    })
 
-    test("Override searchParams in middleware", async ({ expect }) => {
-      const endpoint = createEndpoint(
-        "GET",
-        "/auth/google",
-        async (_, ctx) => {
-          return Response.json({ searchParams: ctx.searchParams });
-        },
-        {
-          schemas: {
-            searchParams: z.object({
-              redirect_uri: z.string(),
-            }),
-          },
-          middlewares: [
-            async (_, ctx) => {
-              const searchParams = ctx.searchParams as any;
-              searchParams.state = "123abc";
-              searchParams.code = "123";
-              return ctx;
-            },
-          ],
-        },
-      );
-      const { GET } = createRouter([endpoint]);
-      const get = await GET(
-        new Request(
-          "https://example.com/auth/google?redirect_uri=https://app.com/callback",
-        ),
-        {} as RequestContext,
-      );
-      expect(get.ok).toBe(true);
-      expect(await get.json()).toEqual({
-        searchParams: {
-          state: "123abc",
-          code: "123",
-          redirect_uri: "https://app.com/callback",
-        },
-      });
-    });
+    describe("With schemas", () => {
+        describe("With body schema", () => {
+            const endpoint = createEndpoint(
+                "POST",
+                "/auth/credentials",
+                async (_, ctx) => {
+                    return Response.json({ body: ctx.body })
+                },
+                {
+                    schemas: {
+                        body: z.object({
+                            username: z.string(),
+                            password: z.string(),
+                        }),
+                    },
+                }
+            )
+            const { POST } = createRouter([endpoint])
 
-    test("Override params in middleware", async ({ expect }) => {
-      const endpoint = createEndpoint(
-        "GET",
-        "/auth/:oauth",
-        async (_, ctx) => {
-          return Response.json({ params: ctx.params });
-        },
-        {
-          schemas: {},
-          middlewares: [
-            async (_, ctx) => {
-              const params = ctx.params as any;
-              params.oauth = "google";
-              return ctx;
-            },
-          ],
-        },
-      );
+            test("With valid body", async ({ expect }) => {
+                const post = await POST(
+                    new Request("https://example.com/auth/credentials", {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({ username: "John", password: "secret" }),
+                    }),
+                    {} as RequestContext
+                )
+                expect(post.ok).toBe(true)
+                expect(await post.json()).toEqual({
+                    body: { username: "John", password: "secret" },
+                })
+            })
 
-      const { GET } = createRouter([endpoint]);
-      const get = await GET(
-        new Request("https://example.com/auth/github"),
-        {} as RequestContext,
-      );
-      expect(get.ok).toBe(true);
-      expect(await get.json()).toEqual({
-        params: { oauth: "google" },
-      });
-    });
-  });
-});
+            test("With invalid body", async ({ expect }) => {
+                await expect(
+                    POST(
+                        new Request("https://example.com/auth/credentials", {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({ username: "John" }),
+                        }),
+                        {} as RequestContext
+                    )
+                ).rejects.toThrowError(/Invalid request body/)
+            })
+        })
+
+        describe("With searchParams schema", () => {
+            const endpoint = createEndpoint(
+                "GET",
+                "/auth/:oauth",
+                async (_, ctx) => {
+                    return Response.json({ searchParams: ctx.searchParams })
+                },
+                {
+                    schemas: {
+                        searchParams: z.object({
+                            state: z.string(),
+                            code: z.string(),
+                        }),
+                    },
+                }
+            )
+            const { GET } = createRouter([endpoint])
+
+            test("With valid searchParams", async ({ expect }) => {
+                const get = await GET(new Request("https://example.com/auth/google?state=123abc&code=123"), {} as RequestContext)
+                expect(get.ok).toBe(true)
+                expect(await get.json()).toEqual({
+                    searchParams: { state: "123abc", code: "123" },
+                })
+            })
+
+            test("With invalid searchParams", async ({ expect }) => {
+                await expect(
+                    GET(new Request("https://example.com/auth/google?state=123abc"), {} as RequestContext)
+                ).rejects.toThrowError(/Invalid search parameters/)
+            })
+        })
+    })
+
+    describe("With middlewares", () => {
+        test("Update params context in middleware", async ({ expect }) => {
+            const endpoint = createEndpoint(
+                "GET",
+                "/auth/:oauth",
+                async (_, ctx) => {
+                    const oauth = ctx.params.oauth
+                    return Response.json({ oauth })
+                },
+                {
+                    middlewares: [
+                        async (_, ctx) => {
+                            ctx.params = { oauth: "google" }
+                            return ctx
+                        },
+                    ],
+                }
+            )
+            const { GET } = createRouter([endpoint])
+            const get = await GET(new Request("https://example.com/auth/github"), {} as RequestContext)
+            expect(get.ok).toBe(true)
+            expect(await get.json()).toEqual({ oauth: "google" })
+        })
+
+        test("Update searchParams context in middleware", async ({ expect }) => {
+            const endpoint = createEndpoint(
+                "GET",
+                "/auth/google",
+                async (_, ctx) => {
+                    const searchParams = Object.fromEntries(ctx.searchParams.entries())
+                    return Response.json({ searchParams })
+                },
+                {
+                    middlewares: [
+                        async (_, ctx) => {
+                            ctx.searchParams.set("state", "123abc")
+                            ctx.searchParams.set("code", "123")
+                            return ctx
+                        },
+                    ],
+                }
+            )
+            const { GET } = createRouter([endpoint])
+            const get = await GET(new Request("https://example.com/auth/google"), {} as RequestContext)
+            expect(get.ok).toBe(true)
+            expect(await get.json()).toEqual({
+                searchParams: { state: "123abc", code: "123" },
+            })
+        })
+
+        test("Update headers context in middleware", async ({ expect }) => {
+            const endpoint = createEndpoint(
+                "GET",
+                "/headers",
+                async (_, ctx) => {
+                    const headers = Object.fromEntries(ctx.headers.entries())
+                    return Response.json({ headers })
+                },
+                {
+                    middlewares: [
+                        async (_, ctx) => {
+                            ctx.headers.set("Authorization", "Bearer token")
+                            return ctx
+                        },
+                    ],
+                }
+            )
+            const { GET } = createRouter([endpoint])
+            const get = await GET(new Request("https://example.com/headers"), {} as RequestContext)
+            expect(get.ok).toBe(true)
+            expect(await get.json()).toEqual({
+                headers: { authorization: "Bearer token" },
+            })
+        })
+    })
+
+    describe("With schemas and middlewares", () => {
+        test("Override body in middleware", async ({ expect }) => {
+            const endpoint = createEndpoint(
+                "POST",
+                "/auth/credentials",
+                async (_, ctx) => {
+                    return Response.json({ body: ctx.body })
+                },
+                {
+                    schemas: {
+                        body: z.object({
+                            username: z.string(),
+                            password: z.string(),
+                        }),
+                    },
+                    middlewares: [
+                        async (_, ctx) => {
+                            const body = ctx.body as any
+                            body.userId = 12
+                            return ctx
+                        },
+                    ],
+                }
+            )
+            const { POST } = createRouter([endpoint])
+
+            const post = await POST(
+                new Request("https://example.com/auth/credentials", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ username: "John", password: "secret" }),
+                }),
+                {} as RequestContext
+            )
+            expect(post.ok).toBe(true)
+            expect(await post.json()).toEqual({
+                body: { username: "John", password: "secret", userId: 12 },
+            })
+        })
+
+        test("Override searchParams in middleware", async ({ expect }) => {
+            const endpoint = createEndpoint(
+                "GET",
+                "/auth/google",
+                async (_, ctx) => {
+                    return Response.json({ searchParams: ctx.searchParams })
+                },
+                {
+                    schemas: {
+                        searchParams: z.object({
+                            redirect_uri: z.string(),
+                        }),
+                    },
+                    middlewares: [
+                        async (_, ctx) => {
+                            const searchParams = ctx.searchParams as any
+                            searchParams.state = "123abc"
+                            searchParams.code = "123"
+                            return ctx
+                        },
+                    ],
+                }
+            )
+            const { GET } = createRouter([endpoint])
+            const get = await GET(
+                new Request("https://example.com/auth/google?redirect_uri=https://app.com/callback"),
+                {} as RequestContext
+            )
+            expect(get.ok).toBe(true)
+            expect(await get.json()).toEqual({
+                searchParams: {
+                    state: "123abc",
+                    code: "123",
+                    redirect_uri: "https://app.com/callback",
+                },
+            })
+        })
+
+        test("Override params in middleware", async ({ expect }) => {
+            const endpoint = createEndpoint(
+                "GET",
+                "/auth/:oauth",
+                async (_, ctx) => {
+                    return Response.json({ params: ctx.params })
+                },
+                {
+                    schemas: {},
+                    middlewares: [
+                        async (_, ctx) => {
+                            const params = ctx.params as any
+                            params.oauth = "google"
+                            return ctx
+                        },
+                    ],
+                }
+            )
+
+            const { GET } = createRouter([endpoint])
+            const get = await GET(new Request("https://example.com/auth/github"), {} as RequestContext)
+            expect(get.ok).toBe(true)
+            expect(await get.json()).toEqual({
+                params: { oauth: "google" },
+            })
+        })
+    })
+})

--- a/test/middlewares.test.ts
+++ b/test/middlewares.test.ts
@@ -1,185 +1,168 @@
-import z from "zod";
-import { describe, expect, test } from "vitest";
-import {
-  executeGlobalMiddlewares,
-  executeMiddlewares,
-} from "../src/middleware.js";
-import type { MiddlewareFunction, RequestContext } from "../src/types.js";
+import z from "zod"
+import { describe, expect, test } from "vitest"
+import { executeGlobalMiddlewares, executeMiddlewares } from "../src/middleware.js"
+import type { MiddlewareFunction, RequestContext } from "../src/types.js"
 
 describe("executeGlobalMiddlewares", () => {
-  test("No middlewares", async () => {
-    const request = new Request("https://example.com");
-    const result = await executeGlobalMiddlewares(request, undefined);
-    expect(result).toEqual(request);
-  });
+    test("No middlewares", async () => {
+        const request = new Request("https://example.com")
+        const result = await executeGlobalMiddlewares(request, undefined)
+        expect(result).toEqual(request)
+    })
 
-  test("Single middleware that modifies request", async () => {
-    const request = new Request("https://example.com");
-    const middleware = async (req: Request) => {
-      const newHeaders = new Headers(req.headers);
-      newHeaders.set("X-Test", "true");
-      return new Request(req, { headers: newHeaders });
-    };
-    const result = await executeGlobalMiddlewares(request, [middleware]);
-    expect(result.headers.get("X-Test")).toBe("true");
-    expect(request.headers.get("X-Test")).toBeNull();
-  });
+    test("Single middleware that modifies request", async () => {
+        const request = new Request("https://example.com")
+        const middleware = async (req: Request) => {
+            const newHeaders = new Headers(req.headers)
+            newHeaders.set("X-Test", "true")
+            return new Request(req, { headers: newHeaders })
+        }
+        const result = await executeGlobalMiddlewares(request, [middleware])
+        expect(result.headers.get("X-Test")).toBe("true")
+        expect(request.headers.get("X-Test")).toBeNull()
+    })
 
-  test("Middleware updates headers directly", async () => {
-    const request = new Request("https://example.com");
-    const middleware = async (req: Request) => {
-      req.headers.set("X-Test-Direct", "true");
-      return req;
-    };
-    const result = await executeGlobalMiddlewares(request, [middleware]);
-    expect(result.headers.get("X-Test-Direct")).toBe("true");
-    expect(request.headers.get("X-Test-Direct")).toBe("true");
-  });
+    test("Middleware updates headers directly", async () => {
+        const request = new Request("https://example.com")
+        const middleware = async (req: Request) => {
+            req.headers.set("X-Test-Direct", "true")
+            return req
+        }
+        const result = await executeGlobalMiddlewares(request, [middleware])
+        expect(result.headers.get("X-Test-Direct")).toBe("true")
+        expect(request.headers.get("X-Test-Direct")).toBe("true")
+    })
 
-  test("Multiple middlewares", async () => {
-    const request = new Request("https://example.com");
-    const middleware1 = async (req: Request) => {
-      const newHeaders = new Headers(req.headers);
-      newHeaders.set("X-Test-1", "true");
-      return new Request(req, { headers: newHeaders });
-    };
-    const middleware2 = async (req: Request) => {
-      const newHeaders = new Headers(req.headers);
-      newHeaders.set("X-Test-2", "true");
-      return new Request(req, { headers: newHeaders });
-    };
-    const result = await executeGlobalMiddlewares(request, [
-      middleware1,
-      middleware2,
-    ]);
-    expect(result.headers.get("X-Test-1")).toBe("true");
-    expect(result.headers.get("X-Test-2")).toBe("true");
-    expect(request.headers.get("X-Test-1")).toBeNull();
-    expect(request.headers.get("X-Test-2")).toBeNull();
-  });
+    test("Multiple middlewares", async () => {
+        const request = new Request("https://example.com")
+        const middleware1 = async (req: Request) => {
+            const newHeaders = new Headers(req.headers)
+            newHeaders.set("X-Test-1", "true")
+            return new Request(req, { headers: newHeaders })
+        }
+        const middleware2 = async (req: Request) => {
+            const newHeaders = new Headers(req.headers)
+            newHeaders.set("X-Test-2", "true")
+            return new Request(req, { headers: newHeaders })
+        }
+        const result = await executeGlobalMiddlewares(request, [middleware1, middleware2])
+        expect(result.headers.get("X-Test-1")).toBe("true")
+        expect(result.headers.get("X-Test-2")).toBe("true")
+        expect(request.headers.get("X-Test-1")).toBeNull()
+        expect(request.headers.get("X-Test-2")).toBeNull()
+    })
 
-  test("Middleware that returns a Response", async () => {
-    const request = new Request("https://example.com");
-    const middleware = async () => {
-      return new Response("Blocked", { status: 403 });
-    };
-    const result = await executeGlobalMiddlewares(request, [middleware]);
-    expect(result).toBeInstanceOf(Response);
-    expect((result as Response).status).toBe(403);
-  });
-});
+    test("Middleware that returns a Response", async () => {
+        const request = new Request("https://example.com")
+        const middleware = async () => {
+            return new Response("Blocked", { status: 403 })
+        }
+        const result = await executeGlobalMiddlewares(request, [middleware])
+        expect(result).toBeInstanceOf(Response)
+        expect((result as Response).status).toBe(403)
+    })
+})
 
 describe("executeMiddlewares", () => {
-  test.concurrent(
-    "Middleware with searchParams and headers context",
-    async ({ expect }) => {
-      const middlewares: MiddlewareFunction[] = [
-        async (_, ctx) => {
-          ctx.searchParams.set("code", "123abc");
-          ctx.headers.set("Content-Type", "application/json");
-          return ctx;
-        },
-      ];
-      const ctx = await executeMiddlewares(
-        new Request("https://example.com"),
-        {
-          searchParams: new URL("https://example.com").searchParams,
-          headers: new Headers(),
-        } as RequestContext,
-        middlewares,
-      );
-      expect(ctx.searchParams.get("code")).toBe("123abc");
-      expect(ctx.headers.get("Content-Type")).toBe("application/json");
-    },
-  );
+    test.concurrent("Middleware with searchParams and headers context", async ({ expect }) => {
+        const middlewares: MiddlewareFunction[] = [
+            async (_, ctx) => {
+                ctx.searchParams.set("code", "123abc")
+                ctx.headers.set("Content-Type", "application/json")
+                return ctx
+            },
+        ]
+        const ctx = await executeMiddlewares(
+            new Request("https://example.com"),
+            {
+                searchParams: new URL("https://example.com").searchParams,
+                headers: new Headers(),
+            } as RequestContext,
+            middlewares
+        )
+        expect(ctx.searchParams.get("code")).toBe("123abc")
+        expect(ctx.headers.get("Content-Type")).toBe("application/json")
+    })
 
-  test.concurrent(
-    "Two middlewares with searchParams and headers context",
-    async ({ expect }) => {
-      const middlewares: MiddlewareFunction[] = [
-        async (_, ctx) => {
-          ctx.searchParams.set("code", "123abc");
-          ctx.searchParams.set("state", "xyz");
-          return ctx;
-        },
-        async (_, ctx) => {
-          ctx.searchParams.set("state", "abc");
-          ctx.headers.set("Authorization", "Bearer token");
-          return ctx;
-        },
-      ];
-      const ctx = await executeMiddlewares(
-        new Request("https://example.com"),
-        {
-          searchParams: new URL("https://example.com").searchParams,
-          headers: new Headers(),
-        } as RequestContext,
-        middlewares,
-      );
-      expect(ctx.searchParams.get("code")).toBe("123abc");
-      expect(ctx.searchParams.get("state")).toBe("abc");
-      expect(ctx.headers.get("Authorization")).toBe("Bearer token");
-    },
-  );
+    test.concurrent("Two middlewares with searchParams and headers context", async ({ expect }) => {
+        const middlewares: MiddlewareFunction[] = [
+            async (_, ctx) => {
+                ctx.searchParams.set("code", "123abc")
+                ctx.searchParams.set("state", "xyz")
+                return ctx
+            },
+            async (_, ctx) => {
+                ctx.searchParams.set("state", "abc")
+                ctx.headers.set("Authorization", "Bearer token")
+                return ctx
+            },
+        ]
+        const ctx = await executeMiddlewares(
+            new Request("https://example.com"),
+            {
+                searchParams: new URL("https://example.com").searchParams,
+                headers: new Headers(),
+            } as RequestContext,
+            middlewares
+        )
+        expect(ctx.searchParams.get("code")).toBe("123abc")
+        expect(ctx.searchParams.get("state")).toBe("abc")
+        expect(ctx.headers.get("Authorization")).toBe("Bearer token")
+    })
 
-  test.concurrent("Invalid middleware", async ({ expect }) => {
-    const middlewares: MiddlewareFunction[] = [undefined as any];
-    await expect(
-      executeMiddlewares(
-        new Request("https://example.com"),
-        {
-          searchParams: new URL("https://example.com").searchParams,
-          headers: new Headers(),
-        } as RequestContext,
-        middlewares,
-      ),
-    ).rejects.toThrowError(/Middleware must be a function/);
-  });
+    test.concurrent("Invalid middleware", async ({ expect }) => {
+        const middlewares: MiddlewareFunction[] = [undefined as any]
+        await expect(
+            executeMiddlewares(
+                new Request("https://example.com"),
+                {
+                    searchParams: new URL("https://example.com").searchParams,
+                    headers: new Headers(),
+                } as RequestContext,
+                middlewares
+            )
+        ).rejects.toThrowError(/Middleware must be a function/)
+    })
 
-  test.concurrent("No middleware", async ({ expect }) => {
-    const ctx = await executeMiddlewares(new Request("https://example.com"), {
-      searchParams: new URL("https://example.com").searchParams,
-      headers: new Headers(),
-    } as RequestContext);
-    expect(ctx.searchParams.get("code")).toBe(null);
-    expect(ctx.searchParams.get("state")).toBe(null);
-    expect(ctx.headers.get("Content-Type")).toBe(null);
-  });
+    test.concurrent("No middleware", async ({ expect }) => {
+        const ctx = await executeMiddlewares(new Request("https://example.com"), {
+            searchParams: new URL("https://example.com").searchParams,
+            headers: new Headers(),
+        } as RequestContext)
+        expect(ctx.searchParams.get("code")).toBe(null)
+        expect(ctx.searchParams.get("state")).toBe(null)
+        expect(ctx.headers.get("Content-Type")).toBe(null)
+    })
 
-  test.concurrent("Middleware with schema", async ({ expect }) => {
-    const searchParamsShema = z.object({
-      code: z.string().optional,
-      state: z.string().optional(),
-    });
-    const middlewares: MiddlewareFunction<
-      Record<string, string>,
-      { schemas: { searchParams: typeof searchParamsShema } }
-    >[] = [
-      async (_, ctx) => {
-        ctx.searchParams.code = "123abc";
-        ctx.searchParams.state = "xyz";
-        return ctx;
-      },
-    ];
+    test.concurrent("Middleware with schema", async ({ expect }) => {
+        const searchParamsShema = z.object({
+            code: z.string().optional,
+            state: z.string().optional(),
+        })
+        const middlewares: MiddlewareFunction<Record<string, string>, { schemas: { searchParams: typeof searchParamsShema } }>[] =
+            [
+                async (_, ctx) => {
+                    ctx.searchParams.code = "123abc"
+                    ctx.searchParams.state = "xyz"
+                    return ctx
+                },
+            ]
 
-    const ctx = await executeMiddlewares(
-      new Request("https://example.com"),
-      {
-        headers: new Headers(),
-        searchParams: {
-          code: "123abc",
-          state: "xyz",
-        },
-        params: {},
-        body: undefined,
-      } as RequestContext<
-        Record<string, string>,
-        { schemas: { searchParams: typeof searchParamsShema } }
-      >,
-      middlewares,
-    );
+        const ctx = await executeMiddlewares(
+            new Request("https://example.com"),
+            {
+                headers: new Headers(),
+                searchParams: {
+                    code: "123abc",
+                    state: "xyz",
+                },
+                params: {},
+                body: undefined,
+            } as RequestContext<Record<string, string>, { schemas: { searchParams: typeof searchParamsShema } }>,
+            middlewares
+        )
 
-    expect(ctx.searchParams.code).toBe("123abc");
-    expect(ctx.searchParams.state).toBe("xyz");
-  });
-});
+        expect(ctx.searchParams.code).toBe("123abc")
+        expect(ctx.searchParams.state).toBe("xyz")
+    })
+})

--- a/test/type.test-d.ts
+++ b/test/type.test-d.ts
@@ -1,525 +1,482 @@
-import { describe, expectTypeOf } from "vitest";
+import { describe, expectTypeOf } from "vitest"
 import type {
-  RoutePattern,
-  GetRouteParams,
-  MiddlewareFunction,
-  RequestContext,
-  EndpointConfig,
-  ContextSearchParams,
-  ContextBody,
-  RouteHandler,
-  RouteEndpoint,
-  InferMethod,
-  EndpointSchemas,
-} from "../src/types.js";
-import type { ZodObject, ZodString } from "zod";
+    RoutePattern,
+    GetRouteParams,
+    MiddlewareFunction,
+    RequestContext,
+    EndpointConfig,
+    ContextSearchParams,
+    ContextBody,
+    RouteHandler,
+    RouteEndpoint,
+    InferMethod,
+    EndpointSchemas,
+} from "../src/types.js"
+import type { ZodObject, ZodString } from "zod"
 
 /**
  * @todo: implement runtime tests for the types
  */
 describe("RoutePattern", () => {
-  expectTypeOf<"/users/:userId/books/:bookId">().toExtend<RoutePattern>();
-  expectTypeOf<"/users/:userId/:bookId">().toExtend<RoutePattern>();
-  // @ts-expect-error
-  expectTypeOf<"-users/:userId/books/:bookId">().toExtend<RoutePattern>();
-  // @ts-expect-error
-  expectTypeOf<"users/:userId/books/:bookId">().toExtend<RoutePattern>();
+    expectTypeOf<"/users/:userId/books/:bookId">().toExtend<RoutePattern>()
+    expectTypeOf<"/users/:userId/:bookId">().toExtend<RoutePattern>()
+    // @ts-expect-error
+    expectTypeOf<"-users/:userId/books/:bookId">().toExtend<RoutePattern>()
+    // @ts-expect-error
+    expectTypeOf<"users/:userId/books/:bookId">().toExtend<RoutePattern>()
 
-  /**
-   * @todo: improve pattern matching
-   */
-  // @ts-expect-error
-  expectTypeOf<"/users/-userId">().toExtend<RoutePattern>();
-  // @ts-expect-error
-  expectTypeOf<"/users/:userId:bookId">().toExtend<RoutePattern>();
-});
+    /**
+     * @todo: improve pattern matching
+     */
+    // @ts-expect-error
+    expectTypeOf<"/users/-userId">().toExtend<RoutePattern>()
+    // @ts-expect-error
+    expectTypeOf<"/users/:userId:bookId">().toExtend<RoutePattern>()
+})
 
 describe("GetRouteParams", () => {
-  expectTypeOf<GetRouteParams<"/users/:userId/books/:bookId">>().toEqualTypeOf<{
-    userId: string;
-    bookId: string;
-  }>();
-  expectTypeOf<GetRouteParams<"/users/:userId/:bookId">>().toEqualTypeOf<{
-    userId: string;
-    bookId: string;
-  }>();
-  /**
-   * @todo: improve the getting of params
-   */
-  expectTypeOf<GetRouteParams<"/users/:userId:bookId">>().toEqualTypeOf<{}>();
-});
+    expectTypeOf<GetRouteParams<"/users/:userId/books/:bookId">>().toEqualTypeOf<{
+        userId: string
+        bookId: string
+    }>()
+    expectTypeOf<GetRouteParams<"/users/:userId/:bookId">>().toEqualTypeOf<{
+        userId: string
+        bookId: string
+    }>()
+    /**
+     * @todo: improve the getting of params
+     */
+    expectTypeOf<GetRouteParams<"/users/:userId:bookId">>().toEqualTypeOf<{}>()
+})
 
 describe("MiddlewareFunction", () => {
-  expectTypeOf<MiddlewareFunction>().toEqualTypeOf<
-    (request: Request, ctx: RequestContext) => Promise<RequestContext>
-  >();
+    expectTypeOf<MiddlewareFunction>().toEqualTypeOf<(request: Request, ctx: RequestContext) => Promise<RequestContext>>()
 
-  expectTypeOf<MiddlewareFunction<{ oauth: string }>>().toEqualTypeOf<
-    (
-      request: Request,
-      ctx: RequestContext<{ oauth: string }>,
-    ) => Promise<RequestContext<{ oauth: string }>>
-  >();
+    expectTypeOf<MiddlewareFunction<{ oauth: string }>>().toEqualTypeOf<
+        (request: Request, ctx: RequestContext<{ oauth: string }>) => Promise<RequestContext<{ oauth: string }>>
+    >()
 
-  expectTypeOf<
-    MiddlewareFunction<{ oauth: string; provider: string }>
-  >().toEqualTypeOf<
-    (
-      request: Request,
-      ctx: RequestContext<{ oauth: string; provider: string }>,
-    ) => Promise<RequestContext<{ oauth: string; provider: string }>>
-  >();
-
-  type Body = ZodObject<{ username: ZodString; password: ZodString }>;
-  type SearchParams = ZodObject<{ code: ZodString; state: ZodString }>;
-  expectTypeOf<
-    MiddlewareFunction<
-      {},
-      {
-        schemas: {
-          body: Body;
-        };
-      }
-    >
-  >().toEqualTypeOf<
-    (
-      request: Request,
-      ctx: RequestContext<
-        {},
-        {
-          schemas: {
-            body: Body;
-          };
-        }
-      >,
-    ) => Promise<
-      RequestContext<
-        {},
-        {
-          schemas: {
-            body: Body;
-          };
-        }
-      >
-    >
-  >();
-
-  expectTypeOf<
-    MiddlewareFunction<
-      {},
-      {
-        schemas: {
-          searchParams: SearchParams;
-        };
-      }
-    >
-  >().toEqualTypeOf<
-    (
-      request: Request,
-      ctx: RequestContext<
-        {},
-        {
-          schemas: {
-            searchParams: SearchParams;
-          };
-        }
-      >,
-    ) => Promise<
-      RequestContext<
-        {},
-        {
-          schemas: {
-            searchParams: SearchParams;
-          };
-        }
-      >
-    >
-  >();
-
-  expectTypeOf<
-    MiddlewareFunction<
-      {},
-      {
-        schemas: {
-          body: Body;
-          searchParams: SearchParams;
-        };
-      }
-    >
-  >().toEqualTypeOf<
-    (
-      request: Request,
-      ctx: RequestContext<
-        {},
-        {
-          schemas: {
-            body: Body;
-            searchParams: SearchParams;
-          };
-        }
-      >,
-    ) => Promise<
-      RequestContext<
-        {},
-        {
-          schemas: {
-            body: Body;
-            searchParams: SearchParams;
-          };
-        }
-      >
-    >
-  >();
-
-  expectTypeOf<
-    MiddlewareFunction<
-      {},
-      {
-        middlewares: [];
-      }
-    >
-  >().toEqualTypeOf<
-    (
-      request: Request,
-      ctx: RequestContext<{}, { middlewares: [] }>,
-    ) => Promise<RequestContext<{}, { middlewares: [] }>>
-  >();
-
-  expectTypeOf<
-    MiddlewareFunction<
-      {},
-      {
-        middlewares: [
-          (
+    expectTypeOf<MiddlewareFunction<{ oauth: string; provider: string }>>().toEqualTypeOf<
+        (
             request: Request,
-            ctx: RequestContext,
-          ) => Promise<RequestContext<{}, { middlewares: [] }>>,
-        ];
-      }
-    >
-  >().toEqualTypeOf<
-    (
-      request: Request,
-      ctx: RequestContext<{}, { middlewares: [] }>,
-    ) => Promise<RequestContext<{}, { middlewares: [] }>>
-  >();
+            ctx: RequestContext<{ oauth: string; provider: string }>
+        ) => Promise<RequestContext<{ oauth: string; provider: string }>>
+    >()
 
-  /**
-   * @todo: fix the error inference on nested middlewares
-   */
-  expectTypeOf<
-    MiddlewareFunction<GetRouteParams<"/auth/:oauth">>
-  >().toEqualTypeOf<
-    (
-      request: Request,
-      ctx: RequestContext<{ oauth: string }, { middlewares: [] }>,
-    ) => Promise<RequestContext<{ oauth: string }, { middlewares: [] }>>
-  >();
+    type Body = ZodObject<{ username: ZodString; password: ZodString }>
+    type SearchParams = ZodObject<{ code: ZodString; state: ZodString }>
+    expectTypeOf<
+        MiddlewareFunction<
+            {},
+            {
+                schemas: {
+                    body: Body
+                }
+            }
+        >
+    >().toEqualTypeOf<
+        (
+            request: Request,
+            ctx: RequestContext<
+                {},
+                {
+                    schemas: {
+                        body: Body
+                    }
+                }
+            >
+        ) => Promise<
+            RequestContext<
+                {},
+                {
+                    schemas: {
+                        body: Body
+                    }
+                }
+            >
+        >
+    >()
 
-  expectTypeOf<
-    MiddlewareFunction<
-      GetRouteParams<"/auth/:oauth">,
-      {
-        schemas: { searchParams: ZodObject<{ state: ZodString }> };
-        middlewares: [];
-      }
-    >
-  >().toEqualTypeOf<
-    (
-      request: Request,
-      ctx: RequestContext<
-        GetRouteParams<"/auth/:oauth">,
-        { schemas: { searchParams: ZodObject<{ state: ZodString }> } }
-      >,
-    ) => Promise<RequestContext<GetRouteParams<"/auth/:oauth">, {}>>
-  >();
-});
+    expectTypeOf<
+        MiddlewareFunction<
+            {},
+            {
+                schemas: {
+                    searchParams: SearchParams
+                }
+            }
+        >
+    >().toEqualTypeOf<
+        (
+            request: Request,
+            ctx: RequestContext<
+                {},
+                {
+                    schemas: {
+                        searchParams: SearchParams
+                    }
+                }
+            >
+        ) => Promise<
+            RequestContext<
+                {},
+                {
+                    schemas: {
+                        searchParams: SearchParams
+                    }
+                }
+            >
+        >
+    >()
+
+    expectTypeOf<
+        MiddlewareFunction<
+            {},
+            {
+                schemas: {
+                    body: Body
+                    searchParams: SearchParams
+                }
+            }
+        >
+    >().toEqualTypeOf<
+        (
+            request: Request,
+            ctx: RequestContext<
+                {},
+                {
+                    schemas: {
+                        body: Body
+                        searchParams: SearchParams
+                    }
+                }
+            >
+        ) => Promise<
+            RequestContext<
+                {},
+                {
+                    schemas: {
+                        body: Body
+                        searchParams: SearchParams
+                    }
+                }
+            >
+        >
+    >()
+
+    expectTypeOf<
+        MiddlewareFunction<
+            {},
+            {
+                middlewares: []
+            }
+        >
+    >().toEqualTypeOf<
+        (request: Request, ctx: RequestContext<{}, { middlewares: [] }>) => Promise<RequestContext<{}, { middlewares: [] }>>
+    >()
+
+    expectTypeOf<
+        MiddlewareFunction<
+            {},
+            {
+                middlewares: [(request: Request, ctx: RequestContext) => Promise<RequestContext<{}, { middlewares: [] }>>]
+            }
+        >
+    >().toEqualTypeOf<
+        (request: Request, ctx: RequestContext<{}, { middlewares: [] }>) => Promise<RequestContext<{}, { middlewares: [] }>>
+    >()
+
+    /**
+     * @todo: fix the error inference on nested middlewares
+     */
+    expectTypeOf<MiddlewareFunction<GetRouteParams<"/auth/:oauth">>>().toEqualTypeOf<
+        (
+            request: Request,
+            ctx: RequestContext<{ oauth: string }, { middlewares: [] }>
+        ) => Promise<RequestContext<{ oauth: string }, { middlewares: [] }>>
+    >()
+
+    expectTypeOf<
+        MiddlewareFunction<
+            GetRouteParams<"/auth/:oauth">,
+            {
+                schemas: { searchParams: ZodObject<{ state: ZodString }> }
+                middlewares: []
+            }
+        >
+    >().toEqualTypeOf<
+        (
+            request: Request,
+            ctx: RequestContext<GetRouteParams<"/auth/:oauth">, { schemas: { searchParams: ZodObject<{ state: ZodString }> } }>
+        ) => Promise<RequestContext<GetRouteParams<"/auth/:oauth">, {}>>
+    >()
+})
 
 describe("ContextSearchParams", () => {
-  describe("URLSearchParams instance", () => {
-    expectTypeOf<ContextSearchParams<undefined>>().toEqualTypeOf<{
-      searchParams: URLSearchParams;
-    }>();
-    expectTypeOf<ContextSearchParams<{}>>().toEqualTypeOf<{
-      searchParams: URLSearchParams;
-    }>();
-  });
+    describe("URLSearchParams instance", () => {
+        expectTypeOf<ContextSearchParams<undefined>>().toEqualTypeOf<{
+            searchParams: URLSearchParams
+        }>()
+        expectTypeOf<ContextSearchParams<{}>>().toEqualTypeOf<{
+            searchParams: URLSearchParams
+        }>()
+    })
 
-  describe("ZodObject instance", () => {
-    expectTypeOf<
-      ContextSearchParams<{
-        searchParams: ZodObject<{
-          code: ZodString;
-        }>;
-      }>
-    >().toEqualTypeOf<{ searchParams: { code: string } }>();
+    describe("ZodObject instance", () => {
+        expectTypeOf<
+            ContextSearchParams<{
+                searchParams: ZodObject<{
+                    code: ZodString
+                }>
+            }>
+        >().toEqualTypeOf<{ searchParams: { code: string } }>()
 
-    expectTypeOf<
-      ContextSearchParams<{
-        searchParams: ZodObject<{
-          code: ZodString;
-          state: ZodString;
-        }>;
-      }>
-    >().toEqualTypeOf<{ searchParams: { code: string; state: string } }>();
-  });
-});
+        expectTypeOf<
+            ContextSearchParams<{
+                searchParams: ZodObject<{
+                    code: ZodString
+                    state: ZodString
+                }>
+            }>
+        >().toEqualTypeOf<{ searchParams: { code: string; state: string } }>()
+    })
+})
 
 describe("ContextBody", () => {
-  describe("undefined body", () => {
-    expectTypeOf<ContextBody<undefined>>().toEqualTypeOf<{ body: undefined }>();
-    expectTypeOf<ContextBody<{}>>().toEqualTypeOf<{ body: undefined }>();
-  });
+    describe("undefined body", () => {
+        expectTypeOf<ContextBody<undefined>>().toEqualTypeOf<{ body: undefined }>()
+        expectTypeOf<ContextBody<{}>>().toEqualTypeOf<{ body: undefined }>()
+    })
 
-  describe("ZodObject instance", () => {
-    expectTypeOf<
-      ContextBody<{
-        body: ZodObject<{
-          username: ZodString;
-          password: ZodString;
-        }>;
-      }>
-    >().toEqualTypeOf<{ body: { username: string; password: string } }>();
+    describe("ZodObject instance", () => {
+        expectTypeOf<
+            ContextBody<{
+                body: ZodObject<{
+                    username: ZodString
+                    password: ZodString
+                }>
+            }>
+        >().toEqualTypeOf<{ body: { username: string; password: string } }>()
 
-    expectTypeOf<
-      ContextBody<{
-        body: ZodObject<{
-          oauth: ZodString;
-        }>;
-      }>
-    >().toEqualTypeOf<{ body: { oauth: string } }>();
-  });
-});
+        expectTypeOf<
+            ContextBody<{
+                body: ZodObject<{
+                    oauth: ZodString
+                }>
+            }>
+        >().toEqualTypeOf<{ body: { oauth: string } }>()
+    })
+})
 
 describe("RequestContext", () => {
-  expectTypeOf<RequestContext>().toEqualTypeOf<{
-    params: Record<string, string>;
-    headers: Headers;
-    body: undefined;
-    searchParams: URLSearchParams;
-  }>();
+    expectTypeOf<RequestContext>().toEqualTypeOf<{
+        params: Record<string, string>
+        headers: Headers
+        body: undefined
+        searchParams: URLSearchParams
+    }>()
 
-  expectTypeOf<RequestContext<{ oauth: string }>>().toEqualTypeOf<{
-    params: { oauth: string };
-    headers: Headers;
-    body: undefined;
-    searchParams: URLSearchParams;
-  }>();
+    expectTypeOf<RequestContext<{ oauth: string }>>().toEqualTypeOf<{
+        params: { oauth: string }
+        headers: Headers
+        body: undefined
+        searchParams: URLSearchParams
+    }>()
 
-  expectTypeOf<
-    RequestContext<{ oauth: string; provider: string }>
-  >().toEqualTypeOf<{
-    params: { oauth: string; provider: string };
-    headers: Headers;
-    body: undefined;
-    searchParams: URLSearchParams;
-  }>();
+    expectTypeOf<RequestContext<{ oauth: string; provider: string }>>().toEqualTypeOf<{
+        params: { oauth: string; provider: string }
+        headers: Headers
+        body: undefined
+        searchParams: URLSearchParams
+    }>()
 
-  expectTypeOf<
-    RequestContext<
-      {},
-      {
-        schemas: {
-          body: ZodObject<{ username: ZodString; password: ZodString }>;
-        };
-      }
-    >
-  >().toEqualTypeOf<{
-    params: {};
-    headers: Headers;
-    body: { username: string; password: string };
-    searchParams: URLSearchParams;
-  }>();
+    expectTypeOf<
+        RequestContext<
+            {},
+            {
+                schemas: {
+                    body: ZodObject<{ username: ZodString; password: ZodString }>
+                }
+            }
+        >
+    >().toEqualTypeOf<{
+        params: {}
+        headers: Headers
+        body: { username: string; password: string }
+        searchParams: URLSearchParams
+    }>()
 
-  expectTypeOf<
-    RequestContext<
-      {},
-      {
-        schemas: {
-          searchParams: ZodObject<{ code: ZodString; state: ZodString }>;
-        };
-      }
-    >
-  >().toEqualTypeOf<{
-    params: {};
-    headers: Headers;
-    body: undefined;
-    searchParams: { code: string; state: string };
-  }>();
+    expectTypeOf<
+        RequestContext<
+            {},
+            {
+                schemas: {
+                    searchParams: ZodObject<{ code: ZodString; state: ZodString }>
+                }
+            }
+        >
+    >().toEqualTypeOf<{
+        params: {}
+        headers: Headers
+        body: undefined
+        searchParams: { code: string; state: string }
+    }>()
 
-  expectTypeOf<
-    RequestContext<
-      {},
-      {
-        schemas: {
-          body: ZodObject<{ username: ZodString; password: ZodString }>;
-          searchParams: ZodObject<{ code: ZodString; state: ZodString }>;
-        };
-      }
-    >
-  >().toEqualTypeOf<{
-    params: {};
-    headers: Headers;
-    body: { username: string; password: string };
-    searchParams: { code: string; state: string };
-  }>();
+    expectTypeOf<
+        RequestContext<
+            {},
+            {
+                schemas: {
+                    body: ZodObject<{ username: ZodString; password: ZodString }>
+                    searchParams: ZodObject<{ code: ZodString; state: ZodString }>
+                }
+            }
+        >
+    >().toEqualTypeOf<{
+        params: {}
+        headers: Headers
+        body: { username: string; password: string }
+        searchParams: { code: string; state: string }
+    }>()
 
-  expectTypeOf<
-    RequestContext<
-      { oauth: string },
-      {
-        schemas: {
-          body: ZodObject<{ username: ZodString; password: ZodString }>;
-          searchParams: ZodObject<{ code: ZodString; state: ZodString }>;
-        };
-      }
-    >
-  >().toEqualTypeOf<{
-    params: { oauth: string };
-    headers: Headers;
-    body: { username: string; password: string };
-    searchParams: { code: string; state: string };
-  }>();
-});
+    expectTypeOf<
+        RequestContext<
+            { oauth: string },
+            {
+                schemas: {
+                    body: ZodObject<{ username: ZodString; password: ZodString }>
+                    searchParams: ZodObject<{ code: ZodString; state: ZodString }>
+                }
+            }
+        >
+    >().toEqualTypeOf<{
+        params: { oauth: string }
+        headers: Headers
+        body: { username: string; password: string }
+        searchParams: { code: string; state: string }
+    }>()
+})
 
 describe("EndpointConfig", () => {
-  expectTypeOf<EndpointConfig>().toEqualTypeOf<{
-    schemas?: EndpointSchemas;
-    middlewares?: MiddlewareFunction<
-      GetRouteParams<"/">,
-      {
-        schemas: EndpointSchemas;
-      }
-    >[];
-  }>();
+    expectTypeOf<EndpointConfig>().toEqualTypeOf<{
+        schemas?: EndpointSchemas
+        middlewares?: MiddlewareFunction<
+            GetRouteParams<"/">,
+            {
+                schemas: EndpointSchemas
+            }
+        >[]
+    }>()
 
-  expectTypeOf<
-    EndpointConfig<
-      "/",
-      {
-        body: ZodObject<{ username: ZodString; password: ZodString }>;
-      }
-    >
-  >().toEqualTypeOf<{
-    schemas?: { body: ZodObject<{ username: ZodString; password: ZodString }> };
-    middlewares?: MiddlewareFunction<
-      GetRouteParams<"/">,
-      {
-        schemas: {
-          body: ZodObject<{ username: ZodString; password: ZodString }>;
-        };
-      }
-    >[];
-  }>();
-});
+    expectTypeOf<
+        EndpointConfig<
+            "/",
+            {
+                body: ZodObject<{ username: ZodString; password: ZodString }>
+            }
+        >
+    >().toEqualTypeOf<{
+        schemas?: { body: ZodObject<{ username: ZodString; password: ZodString }> }
+        middlewares?: MiddlewareFunction<
+            GetRouteParams<"/">,
+            {
+                schemas: {
+                    body: ZodObject<{ username: ZodString; password: ZodString }>
+                }
+            }
+        >[]
+    }>()
+})
 
 describe("RouteHandler", () => {
-  expectTypeOf<RouteHandler<"/auth/:oauth", {}>>().toEqualTypeOf<
-    (
-      request: Request,
-      ctx: RequestContext<GetRouteParams<"/auth/:oauth">, {}>,
-    ) => Promise<Response>
-  >();
-  expectTypeOf<RouteHandler<"/auth/session", {}>>().toEqualTypeOf<
-    (
-      request: Request,
-      ctx: RequestContext<GetRouteParams<"/auth/session">, {}>,
-    ) => Promise<Response>
-  >();
-  expectTypeOf<
-    RouteHandler<
-      "/auth/:oauth",
-      {
-        schemas: {
-          searchParams: ZodObject<{ state: ZodString }>;
-        };
-      }
-    >
-  >().toEqualTypeOf<
-    (
-      request: Request,
-      ctx: RequestContext<
-        GetRouteParams<"/auth/:oauth">,
-        {
-          schemas: {
-            searchParams: ZodObject<{ state: ZodString }>;
-          };
-        }
-      >,
-    ) => Promise<Response>
-  >();
-});
+    expectTypeOf<RouteHandler<"/auth/:oauth", {}>>().toEqualTypeOf<
+        (request: Request, ctx: RequestContext<GetRouteParams<"/auth/:oauth">, {}>) => Promise<Response>
+    >()
+    expectTypeOf<RouteHandler<"/auth/session", {}>>().toEqualTypeOf<
+        (request: Request, ctx: RequestContext<GetRouteParams<"/auth/session">, {}>) => Promise<Response>
+    >()
+    expectTypeOf<
+        RouteHandler<
+            "/auth/:oauth",
+            {
+                schemas: {
+                    searchParams: ZodObject<{ state: ZodString }>
+                }
+            }
+        >
+    >().toEqualTypeOf<
+        (
+            request: Request,
+            ctx: RequestContext<
+                GetRouteParams<"/auth/:oauth">,
+                {
+                    schemas: {
+                        searchParams: ZodObject<{ state: ZodString }>
+                    }
+                }
+            >
+        ) => Promise<Response>
+    >()
+})
 
 describe("RouteEndpoint", () => {
-  expectTypeOf<RouteEndpoint<"GET", "/auth/:oauth", {}>>().toEqualTypeOf<{
-    method: "GET";
-    route: "/auth/:oauth";
-    config: {};
-    handler: RouteHandler<"/auth/:oauth", {}>;
-  }>();
+    expectTypeOf<RouteEndpoint<"GET", "/auth/:oauth", {}>>().toEqualTypeOf<{
+        method: "GET"
+        route: "/auth/:oauth"
+        config: {}
+        handler: RouteHandler<"/auth/:oauth", {}>
+    }>()
 
-  // @ts-expect-error
-  expectTypeOf<RouteEndpoint<"GET", "auth/:oauth", {}>>().toEqualTypeOf<{
-    method: "GET";
-    route: "/auth/:oauth";
-    config: {};
-    handler: RouteHandler<"/auth/:oauth", {}>;
-  }>();
+    // @ts-expect-error
+    expectTypeOf<RouteEndpoint<"GET", "auth/:oauth", {}>>().toEqualTypeOf<{
+        method: "GET"
+        route: "/auth/:oauth"
+        config: {}
+        handler: RouteHandler<"/auth/:oauth", {}>
+    }>()
 
-  expectTypeOf<
-    RouteEndpoint<
-      "GET",
-      "/auth/:oauth",
-      {
-        schemas: {
-          searchParams: ZodObject<{ state: ZodString }>;
-        };
-      }
-    >
-  >().toEqualTypeOf<{
-    method: "GET";
-    route: "/auth/:oauth";
-    config: {
-      schemas: { searchParams: ZodObject<{ state: ZodString }> };
-    };
-    handler: RouteHandler<
-      "/auth/:oauth",
-      {
-        schemas: {
-          searchParams: ZodObject<{ state: ZodString }>;
-        };
-      }
-    >;
-  }>();
-});
+    expectTypeOf<
+        RouteEndpoint<
+            "GET",
+            "/auth/:oauth",
+            {
+                schemas: {
+                    searchParams: ZodObject<{ state: ZodString }>
+                }
+            }
+        >
+    >().toEqualTypeOf<{
+        method: "GET"
+        route: "/auth/:oauth"
+        config: {
+            schemas: { searchParams: ZodObject<{ state: ZodString }> }
+        }
+        handler: RouteHandler<
+            "/auth/:oauth",
+            {
+                schemas: {
+                    searchParams: ZodObject<{ state: ZodString }>
+                }
+            }
+        >
+    }>()
+})
 
 describe("InferMethod", () => {
-  expectTypeOf<
-    InferMethod<[RouteEndpoint<"GET", "/auth/:oauth", {}>]>
-  >().toEqualTypeOf<"GET">();
-  expectTypeOf<
-    InferMethod<
-      [
-        RouteEndpoint<"GET", "/auth/:oauth", {}>,
-        RouteEndpoint<"GET", "/auth/session", {}>,
-      ]
-    >
-  >().toEqualTypeOf<"GET">();
-  expectTypeOf<
-    InferMethod<
-      [
-        RouteEndpoint<"GET", "/auth/:oauth", {}>,
-        RouteEndpoint<"POST", "/auth/signOut", {}>,
-      ]
-    >
-  >().toEqualTypeOf<"GET" | "POST">();
-  expectTypeOf<
-    InferMethod<
-      [
-        RouteEndpoint<"GET", "/auth/:oauth", {}>,
-        RouteEndpoint<"POST", "/auth/signOut", {}>,
-        RouteEndpoint<"PUT", "/auth/session", {}>,
-      ]
-    >
-  >().toEqualTypeOf<"GET" | "POST" | "PUT">();
-});
+    expectTypeOf<InferMethod<[RouteEndpoint<"GET", "/auth/:oauth", {}>]>>().toEqualTypeOf<"GET">()
+    expectTypeOf<
+        InferMethod<[RouteEndpoint<"GET", "/auth/:oauth", {}>, RouteEndpoint<"GET", "/auth/session", {}>]>
+    >().toEqualTypeOf<"GET">()
+    expectTypeOf<
+        InferMethod<[RouteEndpoint<"GET", "/auth/:oauth", {}>, RouteEndpoint<"POST", "/auth/signOut", {}>]>
+    >().toEqualTypeOf<"GET" | "POST">()
+    expectTypeOf<
+        InferMethod<
+            [
+                RouteEndpoint<"GET", "/auth/:oauth", {}>,
+                RouteEndpoint<"POST", "/auth/signOut", {}>,
+                RouteEndpoint<"PUT", "/auth/session", {}>,
+            ]
+        >
+    >().toEqualTypeOf<"GET" | "POST" | "PUT">()
+})

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from "tsup";
+import { defineConfig } from "tsup"
 
 export default defineConfig({
-  entry: ["src"],
-  format: ["esm", "cjs"],
-  dts: true,
-  clean: true,
-});
+    entry: ["src"],
+    format: ["esm", "cjs"],
+    dts: true,
+    clean: true,
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig } from "vitest/config"
 
 export default defineConfig({
-  test: {
-    include: ["test/**/*.test.ts"],
-  },
-});
+    test: {
+        include: ["test/**/*.test.ts"],
+    },
+})


### PR DESCRIPTION
## Description

This pull request adds the missing **default export** for the Prettier configuration and executes the `format` script, which runs the `prettier --write .` command using the defined Prettier configuration options.

> [!NOTE]
> This pull request does not introduce any code changes or new functionality to the codebase — it only ensures the Prettier configuration is properly set up and applied.
