### PR TITLE
feat(router): remove context in handlers

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -27,7 +27,7 @@ export const createRouter = <const Endpoints extends RouteEndpoint[]>(
     }
     endpoints.forEach((endpoint) => groups[endpoint.method].push(endpoint))
     for (const method in groups) {
-        server[method as keyof typeof server] = async (request: Request, ctx: RequestContext) => {
+        server[method as keyof typeof server] = async (request: Request) => {
             try {
                 const globalRequest = await executeGlobalMiddlewares(request, config.middlewares)
                 if (globalRequest instanceof Response) {
@@ -47,7 +47,6 @@ export const createRouter = <const Endpoints extends RouteEndpoint[]>(
                     const searchParams = getSearchParams(globalRequest.url, endpoint.config)
                     const headers = getHeaders(globalRequest)
                     const context = {
-                        ...ctx,
                         params,
                         searchParams,
                         headers,
@@ -60,7 +59,6 @@ export const createRouter = <const Endpoints extends RouteEndpoint[]>(
             } catch (error) {
                 if (error instanceof AuraStackRouterError) {
                     const { message, status, statusText } = error
-                    console.log("StatusText: ", statusText)
                     return Response.json({ message }, { status, statusText })
                 }
                 return Response.json({ message: "Internal Server Error" }, { status: 500 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,7 +140,7 @@ export type InferMethod<Endpoints extends RouteEndpoint[]> = Endpoints extends u
  * Each method is a function that takes a request and context, returning a promise of a response.
  */
 export type GetHttpHandlers<Endpoints extends RouteEndpoint[]> = {
-    [Method in InferMethod<Endpoints>]: (req: Request, ctx: RequestContext) => Promise<Response>
+    [Method in InferMethod<Endpoints>]: (req: Request) => Promise<Response>
 }
 
 /**

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -2,7 +2,7 @@ import z from "zod"
 import { describe, test } from "vitest"
 import { createRouter } from "../src/router.js"
 import { createEndpoint, createRoutePattern } from "../src/endpoint.js"
-import type { HTTPMethod, RoutePattern, RequestContext } from "../src/types.js"
+import type { HTTPMethod, RoutePattern } from "../src/types.js"
 
 describe("createRoutePattern", () => {
     const testCases = [
@@ -124,8 +124,7 @@ describe("createEndpoint", () => {
                         method: "POST",
                         headers: { "Content-Type": "application/json" },
                         body: JSON.stringify({ username: "John", password: "secret" }),
-                    }),
-                    {} as RequestContext
+                    })
                 )
                 expect(post.ok).toBe(true)
                 expect(await post.json()).toEqual({
@@ -139,8 +138,7 @@ describe("createEndpoint", () => {
                         method: "POST",
                         headers: { "Content-Type": "application/json" },
                         body: JSON.stringify({ username: "John" }),
-                    }),
-                    {} as RequestContext
+                    })
                 )
                 expect(post.status).toBe(422)
                 expect(await post.json()).toEqual({ message: "Invalid request body" })
@@ -167,7 +165,7 @@ describe("createEndpoint", () => {
             const { GET } = createRouter([endpoint])
 
             test("With valid searchParams", async ({ expect }) => {
-                const get = await GET(new Request("https://example.com/auth/google?state=123abc&code=123"), {} as RequestContext)
+                const get = await GET(new Request("https://example.com/auth/google?state=123abc&code=123"))
                 expect(get.ok).toBe(true)
                 expect(await get.json()).toEqual({
                     searchParams: { state: "123abc", code: "123" },
@@ -175,10 +173,7 @@ describe("createEndpoint", () => {
             })
 
             test("With invalid searchParams", async ({ expect }) => {
-                const get = await GET(
-                    new Request("https://example.com/auth/google?state=123abc", { method: "GET" }),
-                    {} as RequestContext
-                )
+                const get = await GET(new Request("https://example.com/auth/google?state=123abc", { method: "GET" }))
                 expect(await get.json()).toEqual({ message: "Invalid search parameters" })
                 expect(get.status).toBe(422)
                 expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
@@ -205,7 +200,7 @@ describe("createEndpoint", () => {
                 }
             )
             const { GET } = createRouter([endpoint])
-            const get = await GET(new Request("https://example.com/auth/github"), {} as RequestContext)
+            const get = await GET(new Request("https://example.com/auth/github"))
             expect(get.ok).toBe(true)
             expect(await get.json()).toEqual({ oauth: "google" })
         })
@@ -229,7 +224,7 @@ describe("createEndpoint", () => {
                 }
             )
             const { GET } = createRouter([endpoint])
-            const get = await GET(new Request("https://example.com/auth/google"), {} as RequestContext)
+            const get = await GET(new Request("https://example.com/auth/google"))
             expect(get.ok).toBe(true)
             expect(await get.json()).toEqual({
                 searchParams: { state: "123abc", code: "123" },
@@ -254,7 +249,7 @@ describe("createEndpoint", () => {
                 }
             )
             const { GET } = createRouter([endpoint])
-            const get = await GET(new Request("https://example.com/headers"), {} as RequestContext)
+            const get = await GET(new Request("https://example.com/headers"))
             expect(get.ok).toBe(true)
             expect(await get.json()).toEqual({
                 headers: { authorization: "Bearer token" },
@@ -293,8 +288,7 @@ describe("createEndpoint", () => {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify({ username: "John", password: "secret" }),
-                }),
-                {} as RequestContext
+                })
             )
             expect(post.ok).toBe(true)
             expect(await post.json()).toEqual({
@@ -326,10 +320,7 @@ describe("createEndpoint", () => {
                 }
             )
             const { GET } = createRouter([endpoint])
-            const get = await GET(
-                new Request("https://example.com/auth/google?redirect_uri=https://app.com/callback"),
-                {} as RequestContext
-            )
+            const get = await GET(new Request("https://example.com/auth/google?redirect_uri=https://app.com/callback"))
             expect(get.ok).toBe(true)
             expect(await get.json()).toEqual({
                 searchParams: {
@@ -360,7 +351,7 @@ describe("createEndpoint", () => {
             )
 
             const { GET } = createRouter([endpoint])
-            const get = await GET(new Request("https://example.com/auth/github"), {} as RequestContext)
+            const get = await GET(new Request("https://example.com/auth/github"))
             expect(get.ok).toBe(true)
             expect(await get.json()).toEqual({
                 params: { oauth: "google" },

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -68,7 +68,7 @@ describe("createRouter", () => {
 
         test("Callback handler", async () => {
             const { GET } = router
-            const get = await GET(new Request("https://example.com/auth/callback", { method: "GET" }), {} as RequestContext)
+            const get = await GET(new Request("https://example.com/auth/callback", { method: "GET" }))
             expect(get.status).toBe(200)
             expect(get.ok).toBeTruthy()
             expect(await get.json()).toEqual({ message: "Handle OAuth callback" })
@@ -77,8 +77,7 @@ describe("createRouter", () => {
         test("Sign-in handler", async () => {
             const { GET } = router
             const get = await GET(
-                new Request("https://example.com/auth/signin/google?redirect_uri=url_to_redirect", { method: "GET" }),
-                {} as RequestContext
+                new Request("https://example.com/auth/signin/google?redirect_uri=url_to_redirect", { method: "GET" })
             )
             expect(get.status).toBe(302)
             expect(await get.json()).toEqual({
@@ -91,8 +90,7 @@ describe("createRouter", () => {
             const get = await GET(
                 new Request("https://example.com/auth/signin/google", {
                     method: "GET",
-                }),
-                {} as RequestContext
+                })
             )
             expect(get.status).toBe(422)
             expect(await get.json()).toEqual({ message: "Invalid search parameters" })
@@ -100,10 +98,7 @@ describe("createRouter", () => {
 
         test("Sign-in handler with missing route param", async () => {
             const { GET } = router
-            const get = await GET(
-                new Request("https://example.com/auth/signin?redirect_uri=url_to_redirect", { method: "GET" }),
-                {} as RequestContext
-            )
+            const get = await GET(new Request("https://example.com/auth/signin?redirect_uri=url_to_redirect", { method: "GET" }))
             expect(get.status).toBe(404)
             expect(get.ok).toBeFalsy()
             expect(await get.json()).toEqual({ message: "Not Found" })
@@ -111,7 +106,7 @@ describe("createRouter", () => {
 
         test("Session handler with middleware", async () => {
             const { GET } = router
-            const get = await GET(new Request("https://example.com/auth/session", { method: "GET" }), {} as RequestContext)
+            const get = await GET(new Request("https://example.com/auth/session", { method: "GET" }))
             expect(get.status).toBe(200)
             expect(get.ok).toBeTruthy()
             expect(await get.json()).toEqual({ message: "Get user session" })
@@ -130,8 +125,7 @@ describe("createRouter", () => {
                         username: "John",
                         password: "secret",
                     }),
-                }),
-                {} as RequestContext
+                })
             )
             expect(post.status).toBe(200)
             expect(post.ok).toBeTruthy()
@@ -151,8 +145,7 @@ describe("createRouter", () => {
                 new Request("https://example.com/auth/credentials", {
                     method: "POST",
                     body,
-                }),
-                {} as RequestContext
+                })
             )
             expect(post.status).toBe(200)
             expect(post.ok).toBeTruthy()
@@ -173,8 +166,7 @@ describe("createRouter", () => {
                     body: JSON.stringify({
                         username: "John",
                     }),
-                }),
-                {} as RequestContext
+                })
             )
             expect(await post.json()).toEqual({ message: "Invalid request body" })
             expect(post.status).toBe(422)
@@ -184,19 +176,13 @@ describe("createRouter", () => {
     describe("Invalid endpoints", () => {
         test("No HTTP handlers defined", async () => {
             const router = createRouter([])
-            const post = await (router as any).POST(
-                new Request("https://example.com/auth/callback", { method: "POST" }),
-                {} as RequestContext
-            )
+            const post = await (router as any).POST(new Request("https://example.com/auth/callback", { method: "POST" }))
             expect(post).toBeInstanceOf(Response)
             expect(post.status).toBe(404)
             expect(post.ok).toBeFalsy()
             expect(await post.json()).toEqual({ message: "Not Found" })
 
-            const put = await (router as any).PUT(
-                new Request("https://example.com/auth/callback", { method: "PUT" }),
-                {} as RequestContext
-            )
+            const put = await (router as any).PUT(new Request("https://example.com/auth/callback", { method: "PUT" }))
             expect(put).toBeInstanceOf(Response)
             expect(put.status).toBe(404)
             expect(put.ok).toBeFalsy()
@@ -216,8 +202,7 @@ describe("createRouter", () => {
             const get = await GET(
                 new Request("https://example.com/api/auth/session", {
                     method: "GET",
-                }),
-                {} as RequestContext
+                })
             )
             expect(get.status).toBe(200)
             expect(get.ok).toBeTruthy()
@@ -226,7 +211,7 @@ describe("createRouter", () => {
 
         test("Session handler with missing base path", async () => {
             const { GET } = router
-            const get = await GET(new Request("https://example.com/session", { method: "GET" }), {} as RequestContext)
+            const get = await GET(new Request("https://example.com/session", { method: "GET" }))
             expect(get.status).toBe(404)
             expect(get.ok).toBeFalsy()
             expect(await get.json()).toEqual({ message: "Not Found" })
@@ -254,7 +239,7 @@ describe("createRouter", () => {
             const { GET, POST } = router
 
             test("Add header in GET request", async () => {
-                const get = await GET(new Request("https://example.com/session", { method: "GET" }), {} as RequestContext)
+                const get = await GET(new Request("https://example.com/session", { method: "GET" }))
                 expect(get.status).toBe(200)
                 expect(get.ok).toBeTruthy()
                 expect(get.headers.get("x-powered-by")).toBe("@aura-stack")
@@ -262,7 +247,7 @@ describe("createRouter", () => {
             })
 
             test("Add header in POST request", async () => {
-                const post = await POST(new Request("https://example.com/auth/google", { method: "POST" }), {} as RequestContext)
+                const post = await POST(new Request("https://example.com/auth/google", { method: "POST" }))
                 expect(post.status).toBe(200)
                 expect(post.ok).toBeTruthy()
                 expect(post.headers.get("x-powered-by")).toBe("@aura-stack")
@@ -286,7 +271,7 @@ describe("createRouter", () => {
             const { GET } = router
 
             test("Block request without authorization header", async () => {
-                const get = await GET(new Request("https://example.com/session", { method: "GET" }), {} as RequestContext)
+                const get = await GET(new Request("https://example.com/session", { method: "GET" }))
                 expect(get).toBeInstanceOf(Response)
                 expect(get.status).toBe(403)
                 expect(await get.json()).toEqual({ message: "Forbidden" })


### PR DESCRIPTION
## Description

This pull request removes the **context** argument from the handlers returned by `createRouter` after defining endpoints.  
The goal is to simplify the API by allowing handlers to only receive the **request** object, avoiding the need for an unnecessary context parameter that, in most cases, remained unused.  

This change aligns with common usage patterns in backend frameworks such as **Next.js Route Handlers**, where the context argument is not typically required.

### Visual Changes

**Before**
```ts
const endpoint = createEndpoint("GET", "/hello", async () => {
  return Response.json({ message: "Hello" })
})

const router = createRouter([endpoint])

router.GET(request, context)
//                   ^ In most cases, the second argument was unused
```



**After**
```ts
const endpoint = createEndpoint("GET", "/hello", async () => {
  return Response.json({ message: "Hello" })
})

const router = createRouter([endpoint])

router.GET(request)
//          ^ Only the incoming request is required
```
