### PR TITLE
chore(release): bump package version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ Per-package version history is maintained inside each package’s own `CHANGELOG
 
 ## [Unreleased]
 
+---
+
+## [0.2.0] - 2025-10-23
+
 ### Changed
 
 - Router now only exposes HTTP handlers that are defined via `createRouter`. Undefined HTTP handlers are not exposed, preventing TypeScript errors when accessing non-existent methods. [#8](https://github.com/aura-stack-js/router/pull/8)
+
+- Removed the second `context` argument from the HTTP handler functions returned by `createRouter`. Handlers now accept a single `Request` parameter and return a `Response`. [#6](https://github.com/aura-stack-js/router/pull/6)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/router",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "description": "A lightweight TypeScript library for building, managing, and validating API routes and endpoints in Node.js applications.",
   "scripts": {


### PR DESCRIPTION
## Description

This pull request bumps the package version to **v0.2.0** on npm.  
The new version includes updates to the `createRouter` function, specifically related to the returned HTTP handlers.  
These changes remove the **second context argument** and eliminate **undefined HTTP handlers** from the router to improve type safety and runtime reliability.

### Related PRs
- #8  
- #6  
