### PR TITLE
feat(endpoint): add schemas and type-safe support for dynamic params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Per-package version history is maintained inside each package’s own `CHANGELOG
 
 ## [Unreleased]
 
+### Added
+
+- Added support for Zod schemas to validate dynamic route parameters. Endpoint parameter schemas can be supplied via `createEndpoint` or `createEndpointConfig`; these schemas are used at runtime to validate and coerce parameters and provide stronger compile-time types via Zod inference. [#10](https://github.com/aura-stack-ts/router/pull/10)
+
 ---
 
 ## [0.2.0] - 2025-10-23

--- a/docs/src/content/docs/create-endpoint.mdx
+++ b/docs/src/content/docs/create-endpoint.mdx
@@ -22,12 +22,12 @@ import type {
 
 ## Parameters
 
-| Parameter | Type                                                      | Description                                                        |
-| --------- | --------------------------------------------------------- | ------------------------------------------------------------------ |
-| `method`  | `"GET"` \| `"POST"` \| `"PUT"` \| `"PATCH"` \| `"DELETE"` | HTTP method for the endpoint                                       |
-| `route`   | `RoutePattern`                                            | URL pattern with optional dynamic segments (e.g., `/users/:id`)    |
-| `handler` | `RouteHandler`                                            | Async function that processes the request and returns a `Response` |
-| `config`  | `EndpointConfig`                                          | Optional configuration for schemas and middlewares                 |
+| Parameter | Type                                                                                                             | Description                                                        |
+| --------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `method`  | `"GET"` \| `"POST"` \| `"PUT"` \| `"PATCH"` \| `"DELETE"` \| `"HEAD"` \| `"CONNECT"` \| `"OPTIONS"` \| `"TRACE"` | HTTP method for the endpoint                                       |
+| `route`   | `RoutePattern`                                                                                                   | URL pattern with optional dynamic segments (e.g., `/users/:id`)    |
+| `handler` | `RouteHandler`                                                                                                   | Async function that processes the request and returns a `Response` |
+| `config`  | `EndpointConfig`                                                                                                 | Optional configuration for schemas and middlewares                 |
 
 ## Basic Usage
 
@@ -44,7 +44,7 @@ const getSession = createEndpoint("GET", "/auth/session", async (request, ctx) =
 })
 ```
 
-> Only `GET`, `POST`, `PUT`, `PATCH`, and `DELETE` methods are supported. Using other HTTP methods will result in TypeScript errors.
+> All standard HTTP methods are supported: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `CONNECT`, `OPTIONS`, and `TRACE`. See the [RFC standard](https://datatracker.ietf.org/doc/html/rfc2616) for details.
 
 ## Request Context
 

--- a/docs/src/content/docs/create-endpoint.mdx
+++ b/docs/src/content/docs/create-endpoint.mdx
@@ -89,6 +89,26 @@ const getBookmark = createEndpoint("GET", "/users/:userId/books/:bookId", async 
 })
 ```
 
+With Zod schema (returns typed object)
+
+```ts lineNumbers
+import z from "zod"
+import { createEndpoint, createEndpointConfig } from "@aura-stack/router"
+
+const config = createEndpointConfig("/users/:userId", {
+  schemas: {
+    params: z.object({
+      userId: z.coerce.number(),
+    }),
+  },
+})
+
+const getUser = createEndpoint("GET", "/users/:userId", async (request, ctx) => {
+  const { userId } = ctx.params
+  return Response.json({ id: userId })
+})
+```
+
 ### Search Parameters (`ctx.searchParams`)
 
 Query string parameters are available through `ctx.searchParams`:

--- a/docs/src/content/docs/create-endpoint.mdx
+++ b/docs/src/content/docs/create-endpoint.mdx
@@ -92,7 +92,7 @@ const getBookmark = createEndpoint("GET", "/users/:userId/books/:bookId", async 
 With Zod schema (returns typed object)
 
 ```ts lineNumbers
-import z from "zod"
+import { z } from "zod"
 import { createEndpoint, createEndpointConfig } from "@aura-stack/router"
 
 const config = createEndpointConfig("/users/:userId", {
@@ -103,10 +103,15 @@ const config = createEndpointConfig("/users/:userId", {
   },
 })
 
-const getUser = createEndpoint("GET", "/users/:userId", async (request, ctx) => {
-  const { userId } = ctx.params
-  return Response.json({ id: userId })
-})
+const getUser = createEndpoint(
+  "GET",
+  "/users/:userId",
+  async (request, ctx) => {
+    const { userId } = ctx.params
+    return Response.json({ id: userId })
+  },
+  config
+)
 ```
 
 ### Search Parameters (`ctx.searchParams`)

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -56,6 +56,10 @@ Currently is supoprted five HTTP methods, based on the recommended and suggested
 - `PUT` - Replace resources
 - `PATCH` - Update resources
 - `DELETE` - Delete resources
+- `OPTIONS` - Request supported methods
+- `HEAD` - Headers only response
+- `TRACE` - Diagnostic loopback
+- `CONNECT` - Establish tunnel
 
 ## Route Patterns
 

--- a/docs/src/content/docs/schemas.mdx
+++ b/docs/src/content/docs/schemas.mdx
@@ -13,6 +13,7 @@ Schema validation using Zod ensures type-safe request handling with automatic pa
 
 - Request bodies
 - Query parameters (search params)
+- Route Parameters
 
 When validation fails, an error is thrown automatically.
 
@@ -47,6 +48,9 @@ const searchUsers = createEndpoint(
 ### Advanced Query Validation
 
 ```ts lineNumbers
+import { createEndpointConfig } from "@aura-stack/router"
+import { z } from "zod"
+
 const advancedSearchConfig = createEndpointConfig({
   schemas: {
     searchParams: z.object({
@@ -66,6 +70,9 @@ const advancedSearchConfig = createEndpointConfig({
 ### Basic Body Validation
 
 ```ts lineNumbers
+import { createEndpointConfig, createEndpoint } from "@aura-stack/router"
+import { z } from "zod"
+
 const createUserConfig = createEndpointConfig({
   schemas: {
     body: z.object({
@@ -90,6 +97,9 @@ const createUser = createEndpoint(
 ### Complex Body Validation
 
 ```ts lineNumbers
+import { createEndpointConfig, createEndpoint } from "@aura-stack/router"
+import { z } from "zod"
+
 const updateProfileConfig = createEndpointConfig({
   schemas: {
     body: z.object({
@@ -119,11 +129,42 @@ const updateProfile = createEndpoint(
 )
 ```
 
+## Route Parameters
+
+### Basic Parameters Validation
+
+```ts lineNumbers
+import { createEndpointConfig, createEndpoint } from "@aura-stack/router"
+import { z } from "zod"
+
+const dynamicsConfig = createEndpointConfig("/users/:userId/books/:bookId", {
+  schemas: {
+    params: z.object({
+      userId: z.regex(/^[0-9]+$/),
+      bookId: z.uuid(),
+    }),
+  },
+})
+
+const getBookById = createEndpoint(
+  "GET",
+  "/users/:userId/books/:bookId",
+  async (_, ctx) => {
+    const { userId, bookId } = ctx.params
+    return Response.json({ bookId })
+  },
+  dynamicsConfig
+)
+```
+
 ## Combined Validation
 
 Validate both body and query parameters in the same endpoint:
 
-```ts
+```ts lineNumbers
+import { createEndpointConfig, createEndpoint } from "@aura-stack/router"
+import { z } from "zod"
+
 const createPostConfig = createEndpointConfig({
   schemas: {
     body: z.object({
@@ -165,7 +206,10 @@ const createPost = createEndpoint(
 
 Combine route params with validated schemas:
 
-```ts
+```ts lineNumbers
+import { createEndpointConfig, createEndpoint } from "@aura-stack/router"
+import { z } from "zod"
+
 const updateUserConfig = createEndpointConfig("/users/:userId", {
   schemas: {
     body: z.object({
@@ -215,7 +259,9 @@ Validation errors are automatically thrown with descriptive messages:
 
 ### Custom Error Handling
 
-```ts
+```ts lineNumbers
+import { createRouter } from "@aura-stack/router"
+
 const { POST } = createRouter([createUser])
 
 async function handleRequest(request: Request) {
@@ -243,7 +289,7 @@ async function handleRequest(request: Request) {
 
 ### 1. Use Descriptive Schemas
 
-```ts
+```ts lineNumbers
 // ❌ Too loose
 z.string()
 
@@ -253,7 +299,10 @@ z.string().email().max(255)
 
 ### 2. Provide Default Values
 
-```ts
+```ts lineNumbers
+import { createEndpointConfig } from "@aura-stack/router"
+import { z } from "zod"
+
 const config = createEndpointConfig({
   schemas: {
     searchParams: z.object({
@@ -269,7 +318,9 @@ const config = createEndpointConfig({
 
 Query parameters are always strings, use coercion:
 
-```ts
+```ts lineNumbers
+import { z } from "zod"
+
 z.object({
   page: z.coerce.number(), // Converts "10" to 10
   active: z.coerce.boolean(), // Converts "true" to true
@@ -278,7 +329,10 @@ z.object({
 
 ### 4. Reuse Schemas
 
-```ts
+```ts lineNumbers
+import { createEndpointConfig } from "@aura-stack/router"
+import { z } from "zod"
+
 const userSchema = z.object({
   name: z.string().min(1),
   email: z.string().email(),

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,4 @@
-import type { EndpointConfig, Params, RoutePattern, ContextSearchParams, ContentType } from "./types.js"
+import type { EndpointConfig, GetRouteParams, RoutePattern, ContextSearchParams, ContentType } from "./types.js"
 import { createRoutePattern } from "./endpoint.js"
 import { isSupportedBodyMethod } from "./assert.js"
 import { AuraStackRouterError } from "./error.js"
@@ -21,7 +21,7 @@ import { AuraStackRouterError } from "./error.js"
  * // Expected: { userId: "123", postId: "456" }
  * const params = getRouteParams(route, path);
  */
-export const getRouteParams = <Route extends RoutePattern>(route: Route, path: string): Params<Route> => {
+export const getRouteParams = <Route extends RoutePattern>(route: Route, path: string): GetRouteParams<Route> => {
     const routeRegex = createRoutePattern(route)
     if (!routeRegex.test(path)) {
         throw new AuraStackRouterError("BAD_REQUEST", `Missing required route params for route: ${route}`)
@@ -30,14 +30,14 @@ export const getRouteParams = <Route extends RoutePattern>(route: Route, path: s
         .exec(route)
         ?.slice(1)
         .map((seg) => seg.replace(":", ""))
-    if (!params) return {} as Params<Route>
+    if (!params) return {} as GetRouteParams<Route>
     const values = routeRegex.exec(path)?.slice(1)
     return params.reduce(
         (previous, now, idx) => ({
             ...previous,
             [now]: decodeURIComponent(values?.[idx] ?? ""),
         }),
-        {} as Params<Route>
+        {} as GetRouteParams<Route>
     )
 }
 

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,7 +1,16 @@
-import type { EndpointConfig, EndpointSchemas, HTTPMethod, Prettify, RouteEndpoint, RouteHandler, RoutePattern } from "./types.js"
+import z from "zod/v4"
+import type {
+    EndpointConfig,
+    EndpointSchemas,
+    EnumKey,
+    HTTPMethod,
+    RouteEndpoint,
+    RouteHandler,
+    RoutePattern,
+    ToEnum,
+} from "./types.js"
 import { isSupportedMethod, isValidHandler, isValidRoute } from "./assert.js"
 import { AuraStackRouterError } from "./error.js"
-import z from "zod"
 
 /**
  * Create a RegExp pattern from a route string. This function allows segment the
@@ -102,25 +111,4 @@ export function createEndpointConfig<Route extends RoutePattern, Schemas extends
 export function createEndpointConfig(...args: unknown[]) {
     if (typeof args[0] === "string") return args[1]
     return args[0]
-}
-
-/**
- * Create a Zod literal schema for inferring specific string, number, or boolean values.
- * It is useful for defining route parameters with a limited set of allowed values.
- *
- * @param infer - The specific value to infer (string, number, or boolean)
- * @returns A Zod literal schema for the provided value
- * @example
- * const oauthSchema = createInfer<"google" | "github">();
- *
- * const config = createEndpointConfig("/signIn/:oauth", {
- *   schemas: {
- *     params: z.object({
- *       oauth: oauthSchema
- *     })
- *   }
- * });
- */
-export const createInfer = <T extends string | number | boolean>(infer: T = <T>{}) => {
-    return z.literal(infer)
 }

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,14 +1,5 @@
 import z from "zod/v4"
-import type {
-    EndpointConfig,
-    EndpointSchemas,
-    EnumKey,
-    HTTPMethod,
-    RouteEndpoint,
-    RouteHandler,
-    RoutePattern,
-    ToEnum,
-} from "./types.js"
+import type { EndpointConfig, EndpointSchemas, HTTPMethod, RouteEndpoint, RouteHandler, RoutePattern } from "./types.js"
 import { isSupportedMethod, isValidHandler, isValidRoute } from "./assert.js"
 import { AuraStackRouterError } from "./error.js"
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -42,7 +42,7 @@ export const createRouter = <const Endpoints extends RouteEndpoint[]>(
                 if (endpoint) {
                     const withBasePath = config.basePath ? `${config.basePath}${endpoint.route}` : endpoint.route
                     const body = await getBody(globalRequest, endpoint.config)
-                    const params = getRouteParams(withBasePath as RoutePattern, pathname)
+                    const params = getRouteParams(withBasePath as RoutePattern, pathname, endpoint.config)
                     const searchParams = getSearchParams(globalRequest.url, endpoint.config)
                     const headers = getHeaders(globalRequest)
                     const context = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,15 +159,3 @@ export interface RouterConfig {
     basePath?: RoutePattern
     middlewares?: GlobalMiddleware[]
 }
-
-/**
- * Key type for enum values, can be string or number.
- */
-export type EnumKey = string | number
-
-/**
- * Converts a tuple of enum values into a readonly object mapping each value to itself.
- */
-export type ToEnum<Enum extends readonly EnumKey[]> = Readonly<{
-    [Key in Enum[number]]: Key
-}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,3 +159,15 @@ export interface RouterConfig {
     basePath?: RoutePattern
     middlewares?: GlobalMiddleware[]
 }
+
+/**
+ * Key type for enum values, can be string or number.
+ */
+export type EnumKey = string | number
+
+/**
+ * Converts a tuple of enum values into a readonly object mapping each value to itself.
+ */
+export type ToEnum<Enum extends readonly EnumKey[]> = Readonly<{
+    [Key in Enum[number]]: Key
+}>

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -1,7 +1,7 @@
 import z from "zod"
 import { describe, test } from "vitest"
 import { createRouter } from "../src/router.js"
-import { createEndpoint, createEndpointConfig, createInfer, createRoutePattern } from "../src/endpoint.js"
+import { createEndpoint, createEndpointConfig, createRoutePattern } from "../src/endpoint.js"
 import type { HTTPMethod, RoutePattern } from "../src/types.js"
 
 describe("createRoutePattern", () => {
@@ -162,6 +162,7 @@ describe("createEndpoint", () => {
                     },
                 }
             )
+
             const { GET } = createRouter([endpoint])
 
             test("With valid searchParams", async ({ expect }) => {
@@ -184,8 +185,15 @@ describe("createEndpoint", () => {
             const config = createEndpointConfig("/signIn/:oauth", {
                 schemas: {
                     params: z.object({
-                        //oauth: createInfer<"google" | "github">(),
                         oauth: z.enum(["google", "github"]),
+                    }),
+                },
+            })
+
+            const inferConfig = createEndpointConfig("/type/:typeId", {
+                schemas: {
+                    params: z.object({
+                        typeId: z.enum(["token", "code"]),
                     }),
                 },
             })
@@ -200,7 +208,16 @@ describe("createEndpoint", () => {
                 config
             )
 
-            const { GET } = createRouter([endpoint])
+            const inferEndpoint = createEndpoint(
+                "GET",
+                "/type/:typeId",
+                async (_, ctx) => {
+                    return Response.json({ typeId: ctx.params.typeId })
+                },
+                inferConfig
+            )
+
+            const { GET } = createRouter([endpoint, inferEndpoint])
 
             test("With valid params", async ({ expect }) => {
                 const get = await GET(new Request("https://example.com/signIn/google"))
@@ -208,11 +225,21 @@ describe("createEndpoint", () => {
                 expect(await get.json()).toEqual({ oauth: "google" })
             })
 
-            /**
-             * @todo: Fix type inference in params schema
-             */
             test("With invalid params", async ({ expect }) => {
                 const get = await GET(new Request("https://example.com/signIn/facebook"))
+                expect(get.status).toBe(422)
+                expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
+                expect(await get.json()).toEqual({ message: "Invalid route parameters" })
+            })
+
+            test("With inferred params", async ({ expect }) => {
+                const get = await GET(new Request("https://example.com/type/token"))
+                expect(get.ok).toBe(true)
+                expect(await get.json()).toEqual({ typeId: "token" })
+            })
+
+            test("With invalid inferred params", async ({ expect }) => {
+                const get = await GET(new Request("https://example.com/type/invalid"))
                 expect(get.status).toBe(422)
                 expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
                 expect(await get.json()).toEqual({ message: "Invalid route parameters" })

--- a/test/type.test-d.ts
+++ b/test/type.test-d.ts
@@ -21,14 +21,6 @@ describe("RoutePattern", () => {
     expectTypeOf<"-users/:userId/books/:bookId">().toExtend<RoutePattern>()
     // @ts-expect-error
     expectTypeOf<"users/:userId/books/:bookId">().toExtend<RoutePattern>()
-
-    /**
-     * @todo: improve pattern matching
-     */
-    // @ts-expect-error
-    expectTypeOf<"/users/-userId">().toExtend<RoutePattern>()
-    // @ts-expect-error
-    expectTypeOf<"/users/:userId:bookId">().toExtend<RoutePattern>()
 })
 
 describe("GetRouteParams", () => {
@@ -40,10 +32,6 @@ describe("GetRouteParams", () => {
         userId: string
         bookId: string
     }>()
-    /**
-     * @todo: improve the getting of params
-     */
-    expectTypeOf<GetRouteParams<"/users/:userId:bookId">>().toEqualTypeOf<{}>()
 })
 
 describe("MiddlewareFunction", () => {
@@ -355,7 +343,7 @@ describe("RequestContext", () => {
 })
 
 describe("EndpointConfig", () => {
-    expectTypeOf<EndpointConfig>().toEqualTypeOf<{
+    expectTypeOf<EndpointConfig<"/">>().toEqualTypeOf<{
         schemas?: EndpointSchemas
         middlewares?: MiddlewareFunction<
             GetRouteParams<"/">,


### PR DESCRIPTION
## Description

This pull request adds **schemas for handling dynamic params**, providing **type-safe validation** for the expected parameters passed to an endpoint. This ensures that the received params strictly match the defined schema.  

The schema can be defined either:
- Directly through the `createEndpoint` function, or  
- Via the `createEndpointConfig` function.  

Both approaches maintain **type inference** for the params within the context provided to the endpoint handler.

Additionally, this update includes all HTTP methods defined in the [HTTP/1.1 standard](https://datatracker.ietf.org/doc/html/rfc2616). The newly added methods are:  
`"OPTIONS" | "HEAD" | "TRACE" | "CONNECT"`

Finally, the related documentation has been updated accordingly.
