### PR TITLE
feat(core): add route matching validation in router

### DIFF
--- a/src/assert.ts
+++ b/src/assert.ts
@@ -4,6 +4,8 @@ const supportedMethods = new Set<HTTPMethod>(["GET", "POST", "DELETE", "PUT", "P
 
 const supportedBodyMethods = new Set<HTTPMethod>(["POST", "PUT", "PATCH"])
 
+export const supportedProtocols = new Set(["http:", "https:"])
+
 /**
  * Checks if the provided method is a supported HTTP method.
  *

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -1,6 +1,6 @@
 import type { RouteHandler, HTTPMethod, RoutePattern } from "./types.js"
 
-const supportedMethods = new Set<HTTPMethod>(["GET", "POST", "DELETE", "PUT", "PATCH"])
+const supportedMethods = new Set<HTTPMethod>(["GET", "POST", "DELETE", "PUT", "PATCH", "OPTIONS", "HEAD", "TRACE", "CONNECT"])
 
 const supportedBodyMethods = new Set<HTTPMethod>(["POST", "PUT", "PATCH"])
 

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,4 +1,3 @@
-import z from "zod/v4"
 import type { EndpointConfig, EndpointSchemas, HTTPMethod, RouteEndpoint, RouteHandler, RoutePattern } from "./types.js"
 import { isSupportedMethod, isValidHandler, isValidRoute } from "./assert.js"
 import { AuraStackRouterError } from "./error.js"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import path from "path"
+import { supportedProtocols } from "./assert.js"
+import { AuraStackRouterError } from "./error.js"
 
 /**
  * Sanitizes a given string by decoding URL-encoded characters, replacing multiple
@@ -7,7 +8,60 @@ import path from "path"
  * @param str - The input string to be sanitized.
  * @returns The sanitized string.
  */
-export const sanitizer = (str: string): string => {
-    const decodedUrl = decodeURIComponent(str).replace(/[^a-zA-Z0-9/_-]/g, "")
-    return decodedUrl.replace(/\/{2,}/g, "/").replace(/\/$/, "")
+export const unstable_sanitizer = (str: string): string => {
+    const decodedUrl = decodeURIComponent(str)
+        .replace(/\/{2,}/g, "/")
+        .replace(/\/(\.\/|\/)+/g, "/")
+        .replace(/\/\.\.\//g, "/")
+        .replace(/\s*\/\s*/g, "/")
+    console.log("str: ", str, "\nDecoded URL:", decodedUrl, "\nURL: ", new URL(decodedUrl).toString())
+    try {
+        const url = new URL(decodedUrl)
+        if (!supportedProtocols.has(url.protocol)) {
+            throw new AuraStackRouterError("BAD_REQUEST", `The URL protocol '${url.protocol}' is not supported`)
+        }
+        const segments = url.pathname
+            .split("/")
+            .map((segment) => sanitizeSegment(segment.trim()))
+            .filter((segment) => segment.length > 0 && segment !== "." && segment !== "..")
+        url.pathname = segments.join("/")
+
+        const searchParams = getSearchParams(url)
+        url.search = new URLSearchParams(searchParams).toString()
+        url.hash = ""
+        return url.toString()
+    } catch {
+        throw new AuraStackRouterError("BAD_REQUEST", `The URL '${decodedUrl}' is not valid`)
+    }
+}
+
+const getSearchParams = (url: URL): URLSearchParams => {
+    const searchParams = new URLSearchParams()
+    for (const [key, value] of url.searchParams.entries()) {
+        const sanitizedKey = sanitizeQueryKey(key)
+        const sanitizedValue = sanitizeQueryValue(value)
+        if (sanitizedKey !== "" && sanitizedValue !== "") {
+            searchParams.set(sanitizedKey, sanitizedValue)
+        }
+    }
+    return searchParams
+}
+
+const sanitizeSegment = (str: string): string => {
+    return str
+        .replace(/[<>:"'|?*&]/g, "") // elimina caracteres peligrosos
+        .replace(/%/g, "") // elimina restos de codificación parcial
+        .replace(/\s{2,}/g, " ") // normaliza espacios
+        .trim() // mantiene espacios válidos dentro
+}
+
+const sanitizeQueryKey = (str: string): string => {
+    return str.replace(/[^a-z0-9\-_]/gi, "")
+}
+
+const sanitizeQueryValue = (str: string): string => {
+    return str
+        .replace(/[<>"'&]/g, "")
+        .replace(/\.\.|[./\\]/g, "")
+        .trim()
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,13 @@
+import path from "path"
+
+/**
+ * Sanitizes a given string by decoding URL-encoded characters, replacing multiple
+ * consecutive slashes with a single slash and removing any trailing slash.
+ *
+ * @param str - The input string to be sanitized.
+ * @returns The sanitized string.
+ */
+export const sanitizer = (str: string): string => {
+    const decodedUrl = decodeURIComponent(str).replace(/[^a-zA-Z0-9/_-]/g, "")
+    return decodedUrl.replace(/\/{2,}/g, "/").replace(/\/$/, "")
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,6 @@ export const unstable_sanitizer = (str: string): string => {
         .replace(/\/(\.\/|\/)+/g, "/")
         .replace(/\/\.\.\//g, "/")
         .replace(/\s*\/\s*/g, "/")
-    console.log("str: ", str, "\nDecoded URL:", decodedUrl, "\nURL: ", new URL(decodedUrl).toString())
     try {
         const url = new URL(decodedUrl)
         if (!supportedProtocols.has(url.protocol)) {

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect } from "vitest"
+import { createRouter } from "../src/router.js"
+import { createEndpoint } from "../src/endpoint.js"
+
+describe("Router", () => {
+    const getUser = createEndpoint("GET", "/users/:userId", async (_, ctx) => {
+        return Response.json({ message: `User ID: ${ctx.params.userId}` }, { status: 200 })
+    })
+    const createUser = createEndpoint("POST", "/users", async () => {
+        return Response.json({ message: "User created" }, { status: 201 })
+    })
+
+    const deleteUser = createEndpoint("DELETE", "/users/:userId", async (_, ctx) => {
+        return Response.json({ message: `User ID: ${ctx.params.userId} deleted` }, { status: 200 })
+    })
+
+    const errorEndpoint = createEndpoint("GET", "/faulty", async () => {
+        throw new Error("Unexpected error")
+    })
+
+    const { DELETE, GET, POST } = createRouter([getUser, createUser, deleteUser, errorEndpoint])
+
+    test("GET /users/:userId", async () => {
+        const response = await GET(new Request("https://example.com/users/123", { method: "GET" }))
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({ message: "User ID: 123" })
+    })
+
+    test("POST /users", async () => {
+        const response = await POST(new Request("https://example.com/users", { method: "POST" }))
+        expect(response.status).toBe(201)
+        expect(await response.json()).toEqual({ message: "User created" })
+    })
+
+    test("DELETE /users/:userId", async () => {
+        const response = await DELETE(new Request("https://example.com/users/123", { method: "DELETE" }))
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({ message: "User ID: 123 deleted" })
+    })
+
+    test("Unsupported HTTP method in dynamic route", async () => {
+        const response = await GET(new Request("https://example.com/users/123", { method: "PATCH" }))
+        expect(response.status).toBe(405)
+        expect(await response.json()).toEqual({ message: "The HTTP method 'PATCH' is not allowed" })
+    })
+
+    test("Unsupported HTTP method in static route", async () => {
+        const response = await POST(new Request("https://example.com/users", { method: "PATCH" }))
+        expect(response.status).toBe(405)
+        expect(await response.json()).toEqual({ message: "The HTTP method 'PATCH' is not allowed" })
+    })
+
+    test("Not Found route", async () => {
+        const response = await GET(new Request("https://example.com/unknown", { method: "GET" }))
+        expect(response.status).toBe(404)
+        expect(await response.json()).toEqual({ message: "Not Found" })
+    })
+
+    test("Invalid HTTP method", async () => {
+        const response = await GET(new Request("https://example.com/users/123", { method: "INVALID" }))
+        expect(response.status).toBe(405)
+        expect(await response.json()).toEqual({ message: "The HTTP method 'INVALID' is not supported" })
+    })
+
+    test("Internal Server Error handling", async () => {
+        const response = await GET(new Request("https://example.com/faulty", { method: "GET" }))
+        expect(response.status).toBe(500)
+        expect(await response.json()).toEqual({ message: "Internal Server Error" })
+    })
+
+    test("Case sensitivity of routes", async () => {
+        const response = await GET(new Request("https://example.com/USERS/123", { method: "GET" }))
+        expect(response.status).toBe(404)
+        expect(await response.json()).toEqual({ message: "Not Found" })
+    })
+})

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -194,6 +194,16 @@ describe("createRouter", () => {
             expectTypeOf(router).not.toHaveProperty("POST")
             expectTypeOf(router).not.toHaveProperty("PUT")
         })
+
+        test("Unsupported HTTP method in route", async () => {
+            const get = createEndpoint("GET", "/session", async () => {
+                return Response.json({ message: "Get user session" }, { status: 200 })
+            })
+            const { GET } = createRouter([get])
+            const response = await GET(new Request("https://example.com/session", { method: "DELETE" }))
+            expect(response.status).toBe(405)
+            expect(await response.json()).toEqual({ message: "The HTTP method 'DELETE' is not allowed" })
+        })
     })
 
     describe("With base path", () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,42 +1,97 @@
 import { describe, test, expect } from "vitest"
-import { sanitizer } from "../src/utils.js"
+import { unstable_sanitizer as sanitizer } from "../src/utils.js"
 
 describe("sanitizer", () => {
     const testCases = [
         {
             description: "should decode percent-encoded characters",
-            input: `/users/${encodeURIComponent("john doe")}/profile`,
-            expected: "/users/john doe/profile",
+            input: `https://example.com/users/john doe/profile`,
+            expected: "https://example.com/users/john doe/profile",
         },
         {
             description: "should replace multiple slashes with a single slash",
-            input: "/api//v1///users",
-            expected: "/api/v1/users",
+            input: "https://example.com/api//v1///users",
+            expected: "https://example.com/api/v1/users",
         },
         {
             description: "should remove trailing slash",
-            input: "/products/electronics/",
-            expected: "/products/electronics",
+            input: "https://example.com/products/electronics/",
+            expected: "https://example.com/products/electronics",
         },
         {
             description: "should handle multiple leading and trailing slashes",
-            input: "//api//users///",
-            expected: "/api/users",
+            input: "https://example.com//api//users///",
+            expected: "https://example.com/api/users",
         },
         {
             description: "remove fragment identifiers",
-            input: "/api/users#page=1",
-            expected: "/api/users",
+            input: "https://example.com/api/users#page=1",
+            expected: "https://example.com/api/users",
+        },
+        {
+            description: "remove fragment",
+            input: "https://example.com/api/users?search=john#section2",
+            expected: "https://example.com/api/users?search=john",
+        },
+        {
+            description: "remove spaces around slashes",
+            input: "https://example.com / api / users / ",
+            expected: "https://example.com/api/users",
         },
         {
             description: "remove trailing spaces",
-            input: " /users ",
-            expected: "/users",
+            input: "https://example.com /users ",
+            expected: "https://example.com/users",
         },
         {
             description: "remove spaces within the string",
-            input: "/users         /",
-            expected: "/users",
+            input: "https://example.com/users         /",
+            expected: "https://example.com/users",
+        },
+        {
+            description: "remove leading spaces",
+            input: "https://example.com/users/",
+            expected: "https://example.com/users",
+        },
+        {
+            description: "20",
+            input: "https://example.com/users/%20/profile",
+            expected: "https://example.com/users/profile",
+        },
+        {
+            description: "2f",
+            input: "https://example.com/users/%2f",
+            expected: "https://example.com/users",
+        },
+        {
+            description: "remove parent directory references",
+            input: "https://example.com/users/../",
+            expected: "https://example.com/users",
+        },
+        {
+            description: "remove current directory references",
+            input: "https://example.com/users/./profile/",
+            expected: "https://example.com/users/profile",
+        },
+        {
+            description: "complex case with multiple issues",
+            input: "https://example.com//api/./v1//users/%20john%20doe/../profile/?search=john#section",
+            expected: "https://example.com/api/v1/users/%20john%20doe/profile?search=john",
+        },
+        {
+            description: "handle parent directory references in query parameters",
+            input: "https://example.com/users?search=../",
+            expected: "https://example.com/users",
+        },
+        {
+            description: "handle current directory references in query parameters",
+            input: "https://example.com/users?search=./profile",
+            expected: "https://example.com/users?search=profile",
+        },
+        {
+            description: "",
+            input: "https://example.com/users?query=alert(XSS)",
+            expected: "https://example.com/users?query=alertXSS",
         },
     ]
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from "vitest"
+import { sanitizer } from "../src/utils.js"
+
+describe("sanitizer", () => {
+    const testCases = [
+        {
+            description: "should decode percent-encoded characters",
+            input: `/users/${encodeURIComponent("john doe")}/profile`,
+            expected: "/users/john doe/profile",
+        },
+        {
+            description: "should replace multiple slashes with a single slash",
+            input: "/api//v1///users",
+            expected: "/api/v1/users",
+        },
+        {
+            description: "should remove trailing slash",
+            input: "/products/electronics/",
+            expected: "/products/electronics",
+        },
+        {
+            description: "should handle multiple leading and trailing slashes",
+            input: "//api//users///",
+            expected: "/api/users",
+        },
+        {
+            description: "remove fragment identifiers",
+            input: "/api/users#page=1",
+            expected: "/api/users",
+        },
+        {
+            description: "remove trailing spaces",
+            input: " /users ",
+            expected: "/users",
+        },
+        {
+            description: "remove spaces within the string",
+            input: "/users         /",
+            expected: "/users",
+        },
+    ]
+
+    for (const { description, input, expected } of testCases) {
+        test(description, () => {
+            const result = sanitizer(input)
+            expect(result).toBe(expected)
+        })
+    }
+})


### PR DESCRIPTION
## Description

This pull request adds **route matching validation** to the `createRouter` function, ensuring that only supported HTTP methods and valid routes are processed. This validation prevents the router from handling unsupported HTTP handlers or HTTP methods that are not part of the [HTTP/1.1 standard](https://datatracker.ietf.org/doc/html/rfc2616).

Additionally, new **tests** were added in `tests/http.test.ts` to simulate multiple client requests to the router. These tests highlight the importance of **URL normalization and sanitization** in incoming requests.  

During testing, several incorrect routing behaviors were identified due to malformed or inconsistent URLs. To address this, a new utility named `unstable_sanitizer` was introduced. This function aims to handle and normalize problematic request URLs to ensure more reliable routing behavior.

> [!WARNING]
> The `unstable_sanitizer` is not yet implemented in this PR and will be completed in future pull requests.
