### PR TITLE
feat(router): add `onError` handler option to `createRouter`

### DIFF
--- a/docs/src/content/docs/create-router.mdx
+++ b/docs/src/content/docs/create-router.mdx
@@ -34,6 +34,11 @@ interface RouterConfig {
     Global middlewares
   */
   middlewares?: MiddlewareFunction[]
+
+  /**
+    Error handler function that runs when an error is thrown in a router handler or middleware.
+  */
+  onError?: (error: Error | AuraStackRouterError, request: Request) => Response | Promise<Response>
 }
 ```
 
@@ -152,6 +157,45 @@ const corsMiddleware = async (request, ctx) => {
 
 const router = createRouter([...endpoints], {
   middlewares: [auditMiddleware, corsMiddleware],
+})
+```
+
+### Error handler
+
+The `onError` option accepts a handler that runs when an error is thrown inside the router, by endpoints, or by middlewares. Use the helper `isRouterError` to detect router-specific errors.
+
+The example below shows `onError` handling an error thrown by an endpoint:
+
+```ts lineNumbers
+import { createEndpoint } from "@aura-stack/router"
+
+const session = createEndpoint("GET", "/session", async () => {
+  throw new Error("Unexpected error in GET /session")
+})
+
+const { GET } = createRouter([session], {
+  onError(error) {
+    return Response.json({ error: error.message }, { status: 500 })
+  },
+})
+```
+
+The example below shows how to handle an `AuraStackRouterError` thrown by an endpoint using the router's `onError` handler.
+
+```ts lineNumbers
+import { createEndpoint, isRouterError, AuraStackRouterError } from "@aura-stack/router"
+
+const getUsers = createEndpoint("GET", "/user/:userId", async () => {
+  throw new AuraStackRouterError("BAD_REQUEST", "Invalid user ID")
+})
+
+const { GET } = createRouter([getUsers], {
+  onError(error) {
+    if (isRouterError(error)) {
+      return Response.json({ message: error.message }, { status: error.status })
+    }
+    return Response.json({ message: "Internal Server Error" }, { status: 500 })
+  },
 })
 ```
 

--- a/docs/src/content/docs/create-router.mdx
+++ b/docs/src/content/docs/create-router.mdx
@@ -38,7 +38,7 @@ interface RouterConfig {
   /**
     Error handler function that runs when an error is thrown in a router handler or middleware.
   */
-  onError?: (error: Error | AuraStackRouterError, request: Request) => Response | Promise<Response>
+  onError?: (error: Error | RouterError, request: Request) => Response | Promise<Response>
 }
 ```
 
@@ -180,13 +180,13 @@ const { GET } = createRouter([session], {
 })
 ```
 
-The example below shows how to handle an `AuraStackRouterError` thrown by an endpoint using the router's `onError` handler.
+The example below shows how to handle an `RouterError` thrown by an endpoint using the router's `onError` handler.
 
 ```ts lineNumbers
-import { createEndpoint, isRouterError, AuraStackRouterError } from "@aura-stack/router"
+import { createEndpoint, isRouterError, RouterError } from "@aura-stack/router"
 
 const getUsers = createEndpoint("GET", "/user/:userId", async () => {
-  throw new AuraStackRouterError("BAD_REQUEST", "Invalid user ID")
+  throw new RouterError("BAD_REQUEST", "Invalid user ID")
 })
 
 const { GET } = createRouter([getUsers], {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,11 @@
       "import": "./dist/endpoint.js",
       "require": "./dist/endpoint.cjs"
     },
+    "./error": {
+      "types": "./dist/error.d.ts",
+      "import": "./dist/error.js",
+      "require": "./dist/error.cjs"
+    },
     "./types": "./dist/types.d.ts"
   },
   "keywords": [

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -1,4 +1,4 @@
-import { AuraStackRouterError } from "./error.js"
+import { RouterError } from "./error.js"
 import type { RouteHandler, HTTPMethod, RoutePattern } from "./types.js"
 
 const supportedMethods = new Set<HTTPMethod>(["GET", "POST", "DELETE", "PUT", "PATCH", "OPTIONS", "HEAD", "TRACE", "CONNECT"])
@@ -48,11 +48,11 @@ export const isValidHandler = (handler: unknown): handler is RouteHandler<any, a
 }
 
 /**
- * Asserts that the error is an instance of AuraStackRouterError. It is useful if you want
- * to check if the error thrown by the router is an AuraStackRouterError or by other sources.
+ * Asserts that the error is an instance of RouterError. It is useful if you want
+ * to check if the error thrown by the router is an RouterError or by other sources.
  *
  * @param error - The error to check
- * @returns True if the error is an instance of AuraStackRouterError, false otherwise.
+ * @returns True if the error is an instance of RouterError, false otherwise.
  * @example
  * import { isRouterError } from "aura-stack/router";
  *
@@ -60,10 +60,10 @@ export const isValidHandler = (handler: unknown): handler is RouteHandler<any, a
  *   // Some router operation that may throw an error
  * } catch (error) {
  *  if (isRouterError(error)) {
- *    // Handle AuraStackRouterError
+ *    // Handle RouterError
  *  }
  * }
  */
-export const isRouterError = (error: unknown): error is AuraStackRouterError => {
-    return error instanceof AuraStackRouterError
+export const isRouterError = (error: unknown): error is RouterError => {
+    return error instanceof RouterError
 }

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -1,3 +1,4 @@
+import { AuraStackRouterError } from "./error.js"
 import type { RouteHandler, HTTPMethod, RoutePattern } from "./types.js"
 
 const supportedMethods = new Set<HTTPMethod>(["GET", "POST", "DELETE", "PUT", "PATCH", "OPTIONS", "HEAD", "TRACE", "CONNECT"])
@@ -44,4 +45,25 @@ export const isValidRoute = (route: string): route is RoutePattern => {
  */
 export const isValidHandler = (handler: unknown): handler is RouteHandler<any, any> => {
     return typeof handler === "function"
+}
+
+/**
+ * Asserts that the error is an instance of AuraStackRouterError. It is useful if you want
+ * to check if the error thrown by the router is an AuraStackRouterError or by other sources.
+ *
+ * @param error - The error to check
+ * @returns True if the error is an instance of AuraStackRouterError, false otherwise.
+ * @example
+ * import { isAuraStackRouterError } from "aura-stack/router";
+ *
+ * try {
+ *   // Some router operation that may throw an error
+ * } catch (error) {
+ *  if (isAuraStackRouterError(error)) {
+ *    // Handle AuraStackRouterError
+ *  }
+ * }
+ */
+export const isAuraStackRouterError = (error: unknown): error is AuraStackRouterError => {
+    return error instanceof AuraStackRouterError
 }

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -54,16 +54,16 @@ export const isValidHandler = (handler: unknown): handler is RouteHandler<any, a
  * @param error - The error to check
  * @returns True if the error is an instance of AuraStackRouterError, false otherwise.
  * @example
- * import { isAuraStackRouterError } from "aura-stack/router";
+ * import { isRouterError } from "aura-stack/router";
  *
  * try {
  *   // Some router operation that may throw an error
  * } catch (error) {
- *  if (isAuraStackRouterError(error)) {
+ *  if (isRouterError(error)) {
  *    // Handle AuraStackRouterError
  *  }
  * }
  */
-export const isAuraStackRouterError = (error: unknown): error is AuraStackRouterError => {
+export const isRouterError = (error: unknown): error is AuraStackRouterError => {
     return error instanceof AuraStackRouterError
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,7 +1,7 @@
 import type { EndpointConfig, GetRouteParams, RoutePattern, ContextSearchParams, ContentType } from "./types.js"
 import { createRoutePattern } from "./endpoint.js"
 import { isSupportedBodyMethod } from "./assert.js"
-import { AuraStackRouterError } from "./error.js"
+import { RouterError } from "./error.js"
 
 /**
  * Extracts route parameters from a given path using the specified route pattern.
@@ -28,7 +28,7 @@ export const getRouteParams = <Route extends RoutePattern, Config extends Endpoi
 ) => {
     const routeRegex = createRoutePattern(route)
     if (!routeRegex.test(path)) {
-        throw new AuraStackRouterError("BAD_REQUEST", `Missing required route params for route: ${route}`)
+        throw new RouterError("BAD_REQUEST", `Missing required route params for route: ${route}`)
     }
     const params = routeRegex
         .exec(route)
@@ -46,7 +46,7 @@ export const getRouteParams = <Route extends RoutePattern, Config extends Endpoi
     if (config.schemas?.params) {
         const parsed = config.schemas.params.safeParse(dynamicParams)
         if (!parsed.success) {
-            throw new AuraStackRouterError("UNPROCESSABLE_ENTITY", "Invalid route parameters")
+            throw new RouterError("UNPROCESSABLE_ENTITY", "Invalid route parameters")
         }
         return parsed.data
     }
@@ -92,7 +92,7 @@ export const getSearchParams = <Config extends EndpointConfig>(
     if (config.schemas?.searchParams) {
         const parsed = config.schemas.searchParams.safeParse(Object.fromEntries(route.searchParams.entries()))
         if (!parsed.success) {
-            throw new AuraStackRouterError("UNPROCESSABLE_ENTITY", "Invalid search parameters")
+            throw new RouterError("UNPROCESSABLE_ENTITY", "Invalid search parameters")
         }
         return parsed.data
     }
@@ -139,7 +139,7 @@ export const getBody = async <Config extends EndpointConfig>(request: Request, c
         if (config.schemas?.body) {
             const parsed = config.schemas.body.safeParse(json)
             if (!parsed.success) {
-                throw new AuraStackRouterError("UNPROCESSABLE_ENTITY", "Invalid request body")
+                throw new RouterError("UNPROCESSABLE_ENTITY", "Invalid request body")
             }
             return parsed.data
         }
@@ -159,7 +159,7 @@ export const getBody = async <Config extends EndpointConfig>(request: Request, c
     }
     /**
      * @todo: Handle other content types
-     * throw new AuraStackRouterError("UNSUPPORTED_MEDIA_TYPE", `Unsupported Content-Type: ${contentType}`)
+     * throw new RouterError("UNSUPPORTED_MEDIA_TYPE", `Unsupported Content-Type: ${contentType}`)
      */
     return null
 }

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,6 +1,6 @@
 import type { EndpointConfig, EndpointSchemas, HTTPMethod, RouteEndpoint, RouteHandler, RoutePattern } from "./types.js"
 import { isSupportedMethod, isValidHandler, isValidRoute } from "./assert.js"
-import { AuraStackRouterError } from "./error.js"
+import { RouterError } from "./error.js"
 
 /**
  * Create a RegExp pattern from a route string. This function allows segment the
@@ -45,13 +45,13 @@ export const createEndpoint = <
     config: EndpointConfig<Route, Schemas> = {}
 ): RouteEndpoint<Method, Route, {}> => {
     if (!isSupportedMethod(method)) {
-        throw new AuraStackRouterError("METHOD_NOT_ALLOWED", `Unsupported HTTP method: ${method}`)
+        throw new RouterError("METHOD_NOT_ALLOWED", `Unsupported HTTP method: ${method}`)
     }
     if (!isValidRoute(route)) {
-        throw new AuraStackRouterError("BAD_REQUEST", `Invalid route format: ${route}`)
+        throw new RouterError("BAD_REQUEST", `Invalid route format: ${route}`)
     }
     if (!isValidHandler(handler)) {
-        throw new AuraStackRouterError("BAD_REQUEST", "Handler must be a function")
+        throw new RouterError("BAD_REQUEST", "Handler must be a function")
     }
     return { method, route, handler, config }
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,7 +1,7 @@
 /**
  * The HTTP status codes used in AuraStack Router.
  */
-const statusCode = {
+export const statusCode = {
     OK: 200,
     CREATED: 201,
     ACCEPTED: 202,
@@ -31,7 +31,7 @@ const statusCode = {
 /**
  * Reverse mapping of status codes to their corresponding status text.
  */
-const statusText = Object.entries(statusCode).reduce(
+export const statusText = Object.entries(statusCode).reduce(
     (previous, [status, code]) => {
         return { ...previous, [code]: status as keyof typeof statusCode }
     },
@@ -43,7 +43,24 @@ const statusText = Object.entries(statusCode).reduce(
  * status text.
  */
 export class AuraStackRouterError extends Error {
+    /**
+     * The HTTP status code associated with the error.
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status
+     * @example
+     * NOT_FOUND: 404
+     * METHOD_NOT_ALLOWED: 405
+     * INTERNAL_SERVER_ERROR: 500
+     */
     public readonly status: number
+
+    /**
+     * The HTTP status text associated with the status code of the error.
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status
+     * @example
+     * 404: NOT_FOUND
+     * 405: METHOD_NOT_ALLOWED
+     * 500: INTERNAL_SERVER_ERROR
+     */
     public readonly statusText: keyof typeof statusCode
 
     constructor(type: keyof typeof statusCode, message: string, name?: string) {

--- a/src/error.ts
+++ b/src/error.ts
@@ -28,14 +28,16 @@ export const statusCode = {
     HTTP_VERSION_NOT_SUPPORTED: 505,
 }
 
+type StatusCode = keyof typeof statusCode
+
 /**
  * Reverse mapping of status codes to their corresponding status text.
  */
-export const statusText = Object.entries(statusCode).reduce(
-    (previous, [status, code]) => {
-        return { ...previous, [code]: status as keyof typeof statusCode }
+export const statusText = Object.keys(statusCode).reduce(
+    (previous, status) => {
+        return { ...previous, [status]: status }
     },
-    {} as Record<number, keyof typeof statusCode>
+    {} as Record<StatusCode, StatusCode>
 )
 
 /**
@@ -57,16 +59,16 @@ export class AuraStackRouterError extends Error {
      * The HTTP status text associated with the status code of the error.
      * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status
      * @example
-     * 404: NOT_FOUND
-     * 405: METHOD_NOT_ALLOWED
-     * 500: INTERNAL_SERVER_ERROR
+     * NOT_FOUND: NOT_FOUND
+     * METHOD_NOT_ALLOWED: METHOD_NOT_ALLOWED
+     * INTERNAL_SERVER_ERROR: INTERNAL_SERVER_ERROR
      */
-    public readonly statusText: keyof typeof statusCode
+    public readonly statusText: StatusCode
 
-    constructor(type: keyof typeof statusCode, message: string, name?: string) {
+    constructor(type: StatusCode, message: string, name?: string) {
         super(message)
         this.name = name ?? "AuraStackRouterError"
         this.status = statusCode[type]
-        this.statusText = statusText[this.status]
+        this.statusText = statusText[type]
     }
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -43,6 +43,7 @@ export const statusText = Object.keys(statusCode).reduce(
 /**
  * Defines the errors used in AuraStack Router. Includes HTTP status code and
  * status text.
+ * @deprecated Use RouterError instead
  */
 export class AuraStackRouterError extends Error {
     /**
@@ -67,8 +68,15 @@ export class AuraStackRouterError extends Error {
 
     constructor(type: StatusCode, message: string, name?: string) {
         super(message)
-        this.name = name ?? "AuraStackRouterError"
+        this.name = name ?? "RouterError"
         this.status = statusCode[type]
         this.statusText = statusText[type]
+    }
+}
+
+export class RouterError extends AuraStackRouterError {
+    constructor(type: StatusCode, message: string, name?: string) {
+        super(type, message, name)
+        this.name = name ?? "RouterError"
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { createEndpoint, createEndpointConfig } from "./endpoint.js"
 export { createRouter } from "./router.js"
 export { isRouterError } from "./assert.js"
-export { AuraStackRouterError, statusCode, statusText } from "./error.js"
+export { RouterError, statusCode, statusText } from "./error.js"
 export type * from "./types.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { createEndpoint, createEndpointConfig } from "./endpoint.js"
 export { createRouter } from "./router.js"
 export { isRouterError } from "./assert.js"
+export { AuraStackRouterError, statusCode, statusText } from "./error.js"
 export type * from "./types.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { createEndpoint, createEndpointConfig } from "./endpoint.js"
 export { createRouter } from "./router.js"
-export { isAuraStackRouterError } from "./assert.js"
+export { isRouterError } from "./assert.js"
 export type * from "./types.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { createEndpoint, createEndpointConfig } from "./endpoint.js"
 export { createRouter } from "./router.js"
+export { isAuraStackRouterError } from "./assert.js"
 export type * from "./types.js"

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -1,4 +1,4 @@
-import { AuraStackRouterError } from "./error.js"
+import { RouterError } from "./error.js"
 import type { EndpointConfig, MiddlewareFunction, RequestContext, RouterConfig } from "./types.js"
 
 /**
@@ -12,7 +12,7 @@ export const executeGlobalMiddlewares = async (request: Request, middlewares: Ro
     if (!middlewares) return request
     for (const middleware of middlewares) {
         if (typeof middleware !== "function") {
-            throw new AuraStackRouterError("BAD_REQUEST", "Global middlewares must be functions")
+            throw new RouterError("BAD_REQUEST", "Global middlewares must be functions")
         }
         const executed = await middleware(request)
         if (executed instanceof Response) {
@@ -21,7 +21,7 @@ export const executeGlobalMiddlewares = async (request: Request, middlewares: Ro
         request = executed
     }
     if (!request || !(request instanceof Request)) {
-        throw new AuraStackRouterError("BAD_REQUEST", "Global middleware must return a Request or Response object")
+        throw new RouterError("BAD_REQUEST", "Global middleware must return a Request or Response object")
     }
     return request
 }
@@ -43,12 +43,12 @@ export const executeMiddlewares = async <const RouteParams extends Record<string
         let ctx = context
         for (const middleware of middlewares) {
             if (typeof middleware !== "function") {
-                throw new AuraStackRouterError("BAD_REQUEST", "Middleware must be a function")
+                throw new RouterError("BAD_REQUEST", "Middleware must be a function")
             }
             ctx = await middleware(request, ctx)
         }
         return ctx
     } catch {
-        throw new AuraStackRouterError("BAD_REQUEST", "Handler threw an error")
+        throw new RouterError("BAD_REQUEST", "Handler threw an error")
     }
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -79,6 +79,17 @@ const matchRoute = async (
         }
         throw new AuraStackRouterError("NOT_FOUND", "Not Found")
     } catch (error) {
+        if (config.onError) {
+            try {
+                const response = await config.onError(error as Error | AuraStackRouterError, request)
+                return response
+            } catch {
+                return Response.json(
+                    { message: "A critical failure occurred during error handling" },
+                    { status: 500, statusText: "Internal Server Error" }
+                )
+            }
+        }
         if (error instanceof AuraStackRouterError) {
             const { message, status, statusText } = error
             return Response.json({ message }, { status, statusText })

--- a/src/router.ts
+++ b/src/router.ts
@@ -3,7 +3,7 @@ import { createRoutePattern } from "./endpoint.js"
 import { getBody, getHeaders, getRouteParams, getSearchParams } from "./context.js"
 import { executeGlobalMiddlewares, executeMiddlewares } from "./middlewares.js"
 import { AuraStackRouterError, statusText } from "./error.js"
-import { isSupportedMethod } from "./assert.js"
+import { isRouterError, isSupportedMethod } from "./assert.js"
 
 /**
  * Creates the entry point for the server, handling the endpoints defined in the router.
@@ -90,7 +90,7 @@ const matchRoute = async (
                 )
             }
         }
-        if (error instanceof AuraStackRouterError) {
+        if (isRouterError(error)) {
             const { message, status, statusText } = error
             return Response.json({ message }, { status, statusText })
         }

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,7 +2,7 @@ import type { HTTPMethod, RequestContext, RouteEndpoint, RoutePattern, RouterCon
 import { createRoutePattern } from "./endpoint.js"
 import { getBody, getHeaders, getRouteParams, getSearchParams } from "./context.js"
 import { executeGlobalMiddlewares, executeMiddlewares } from "./middlewares.js"
-import { AuraStackRouterError } from "./error.js"
+import { AuraStackRouterError, statusText } from "./error.js"
 import { isSupportedMethod } from "./assert.js"
 
 /**
@@ -86,7 +86,7 @@ const matchRoute = async (
             } catch {
                 return Response.json(
                     { message: "A critical failure occurred during error handling" },
-                    { status: 500, statusText: "Internal Server Error" }
+                    { status: 500, statusText: statusText.INTERNAL_SERVER_ERROR }
                 )
             }
         }
@@ -94,6 +94,6 @@ const matchRoute = async (
             const { message, status, statusText } = error
             return Response.json({ message }, { status, statusText })
         }
-        return Response.json({ message: "Internal Server Error" }, { status: 500, statusText: "Internal Server Error" })
+        return Response.json({ message: "Internal Server Error" }, { status: 500, statusText: statusText.INTERNAL_SERVER_ERROR })
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { type ZodObject, z } from "zod"
-import { AuraStackRouterError } from "./error.js"
+import { RouterError } from "./error.js"
 
 /**
  * Route pattern must start with a slash and can contain parameters prefixed with a colon.
@@ -188,7 +188,7 @@ export interface RouterConfig {
     /**
      * Error handler function that runs when an error is thrown in a router handler or middleware.
      * It can be used to customize the default error response provided by the router. If is an internal
-     * error the error is from the `AuraStackRouterError` class, otherwise the error is a generic
+     * error the error is from the `RouterError` class, otherwise the error is a generic
      * `Error` instance which was caused by a handler or middleware, for how to distinguish them you can use
      * the `isRouterError` function from the `assert` module.
      *
@@ -203,5 +203,5 @@ export interface RouterConfig {
      *   return Response.json({ message: "Internal Server Error" }, { status: 500 })
      * }
      */
-    onError?: (error: Error | AuraStackRouterError, request: Request) => Response | Promise<Response>
+    onError?: (error: Error | RouterError, request: Request) => Response | Promise<Response>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,14 +190,14 @@ export interface RouterConfig {
      * It can be used to customize the default error response provided by the router. If is an internal
      * error the error is from the `AuraStackRouterError` class, otherwise the error is a generic
      * `Error` instance which was caused by a handler or middleware, for how to distinguish them you can use
-     * the `isAuraStackRouterError` function from the `assert` module.
+     * the `isRouterError` function from the `assert` module.
      *
      * @param error - The error thrown in the router
      * @param request - The original request that caused the error
      * @returns A response to be sent back to the client
      * @example
      * onError: (error, request) => {
-     *   if(isAuraStackRouterError(error)) {
+     *   if(isRouterError(error)) {
      *     return Response.json({ message: error.message }, { status: error.statusCode })
      *   }
      *   return Response.json({ message: "Internal Server Error" }, { status: 500 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { supportedProtocols } from "./assert.js"
-import { AuraStackRouterError } from "./error.js"
+import { RouterError } from "./error.js"
 
 /**
  * Sanitizes a given string by decoding URL-encoded characters, replacing multiple
@@ -17,7 +17,7 @@ export const unstable_sanitizer = (str: string): string => {
     try {
         const url = new URL(decodedUrl)
         if (!supportedProtocols.has(url.protocol)) {
-            throw new AuraStackRouterError("BAD_REQUEST", `The URL protocol '${url.protocol}' is not supported`)
+            throw new RouterError("BAD_REQUEST", `The URL protocol '${url.protocol}' is not supported`)
         }
         const segments = url.pathname
             .split("/")
@@ -30,7 +30,7 @@ export const unstable_sanitizer = (str: string): string => {
         url.hash = ""
         return url.toString()
     } catch {
-        throw new AuraStackRouterError("BAD_REQUEST", `The URL '${decodedUrl}' is not valid`)
+        throw new RouterError("BAD_REQUEST", `The URL '${decodedUrl}' is not valid`)
     }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,10 +48,10 @@ const getSearchParams = (url: URL): URLSearchParams => {
 
 const sanitizeSegment = (str: string): string => {
     return str
-        .replace(/[<>:"'|?*&]/g, "") // elimina caracteres peligrosos
-        .replace(/%/g, "") // elimina restos de codificación parcial
-        .replace(/\s{2,}/g, " ") // normaliza espacios
-        .trim() // mantiene espacios válidos dentro
+        .replace(/[<>:"'|?*&]/g, "")
+        .replace(/%/g, "")
+        .replace(/\s{2,}/g, " ")
+        .trim()
 }
 
 const sanitizeQueryKey = (str: string): string => {

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -2,7 +2,7 @@ import z from "zod"
 import { describe, expect, expectTypeOf, test } from "vitest"
 import { createRouter } from "../src/router.js"
 import { createEndpoint, createEndpointConfig } from "../src/endpoint.js"
-import { isAuraStackRouterError } from "../src/assert.js"
+import { isRouterError } from "../src/assert.js"
 import { AuraStackRouterError } from "../src/error.js"
 
 describe("createRouter", () => {
@@ -329,10 +329,10 @@ describe("createRouter", () => {
             expect(await get.json()).toEqual({ message: "A critical failure occurred during error handling" })
         })
 
-        test("Handle unexpected error with isAuraStackRouterError", async () => {
+        test("Handle unexpected error with isRouterError", async () => {
             const { GET } = createRouter([getUsers], {
                 onError(error) {
-                    if (isAuraStackRouterError(error)) {
+                    if (isRouterError(error)) {
                         return Response.json({ message: error.message }, { status: error.status })
                     }
                     return Response.json({ message: "Internal Server Error" }, { status: 500 })

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, expectTypeOf, test } from "vitest"
 import { createRouter } from "../src/router.js"
 import { createEndpoint, createEndpointConfig } from "../src/endpoint.js"
 import { isRouterError } from "../src/assert.js"
-import { AuraStackRouterError } from "../src/error.js"
+import { RouterError } from "../src/error.js"
 
 describe("createRouter", () => {
     describe("OAuth endpoints", () => {
@@ -303,7 +303,7 @@ describe("createRouter", () => {
         })
 
         const getUsers = createEndpoint("GET", "/user/:userId", async () => {
-            throw new AuraStackRouterError("BAD_REQUEST", "Invalid user ID")
+            throw new RouterError("BAD_REQUEST", "Invalid user ID")
         })
 
         test("Handle unexpected error with custom error handler", async () => {

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -2,6 +2,8 @@ import z from "zod"
 import { describe, expect, expectTypeOf, test } from "vitest"
 import { createRouter } from "../src/router.js"
 import { createEndpoint, createEndpointConfig } from "../src/endpoint.js"
+import { isAuraStackRouterError } from "../src/assert.js"
+import { AuraStackRouterError } from "../src/error.js"
 
 describe("createRouter", () => {
     describe("OAuth endpoints", () => {
@@ -292,6 +294,53 @@ describe("createRouter", () => {
                 expect(get.status).toBe(403)
                 expect(await get.json()).toEqual({ message: "Forbidden" })
             })
+        })
+    })
+
+    describe("Custom error handler", () => {
+        const session = createEndpoint("GET", "/session", async () => {
+            throw new Error("Unexpected error in GET /session")
+        })
+
+        const getUsers = createEndpoint("GET", "/user/:userId", async () => {
+            throw new AuraStackRouterError("BAD_REQUEST", "Invalid user ID")
+        })
+
+        test("Handle unexpected error with custom error handler", async () => {
+            const { GET } = createRouter([session], {
+                onError(error) {
+                    return Response.json({ error: error.message }, { status: 500 })
+                },
+            })
+
+            const get = await GET(new Request("https://example.com/session", { method: "GET" }))
+            expect(get.status).toBe(500)
+            expect(await get.json()).toEqual({ error: "Unexpected error in GET /session" })
+        })
+
+        test("Handle internal error within error handler", async () => {
+            const { GET } = createRouter([session], {
+                onError() {
+                    throw new Error("Error within error handler")
+                },
+            })
+            const get = await GET(new Request("https://example.com/session", { method: "GET" }))
+            expect(get.status).toBe(500)
+            expect(await get.json()).toEqual({ message: "A critical failure occurred during error handling" })
+        })
+
+        test("Handle unexpected error with isAuraStackRouterError", async () => {
+            const { GET } = createRouter([getUsers], {
+                onError(error) {
+                    if (isAuraStackRouterError(error)) {
+                        return Response.json({ message: error.message }, { status: error.status })
+                    }
+                    return Response.json({ message: "Internal Server Error" }, { status: 500 })
+                },
+            })
+            const get = await GET(new Request("https://example.com/user/12", { method: "GET" }))
+            expect(get.status).toBe(400)
+            expect(await get.json()).toEqual({ message: "Invalid user ID" })
         })
     })
 })


### PR DESCRIPTION
## Description

This pull request introduces the `onError` handler in the `createRouter` configuration, allowing users to **customize error handling** for errors that occur internally within the router or inside any HTTP handler (endpoint) during execution.  

With this change, users can define how the router responds when an error is thrown—providing full control over the returned response structure and content. The `onError` handler receives two parameters: the thrown `error` and the corresponding `request`.  

Additionally, this PR introduces the `isRouterError` utility function, which checks whether a given error is an instance of the internal `RouterError` class, replacing the deprecated `AuraStackRouterError`.

### `RouterError`
The `RouterError` includes three main attributes:
- **statusCode** – The HTTP status code associated with the error.  
- **statusText** – A descriptive status text related to the response code.  
- **message** – Additional information or context about the error.  

These attributes can be used for logging, debugging, or customizing error responses in applications using Aura Stack Router.

### Key Changes
- Add `onError` configuration option in `createRouter`.  
- Deprecate `AuraStackRouterError`.  
- Add new `RouterError` class to replace the old version.  
- Add `isRouterError` helper function.  
