### PR TITLE
feat(core): clone request to safely parse body

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,18 @@ export type HTTPMethod = "GET" | "POST" | "DELETE" | "PUT" | "PATCH" | "OPTIONS"
 /**
  * Content types supported by the router.
  */
-export type ContentType = "application/json" | "application/x-www-form-urlencoded" | "text/plain"
+export type ContentType =
+    | "application/json"
+    | "application/x-www-form-urlencoded"
+    | "text/plain"
+    | "multipart/form-data"
+    | "application/xml"
+    | "application/octet-stream"
+    | `text/${string}`
+    | `image/${string}`
+    | `video/${string}`
+    | `audio/${string}`
+    | "application/pdf"
 
 export type Prettify<Obj extends object> = {
     [Key in keyof Obj]: Obj[Key]

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -511,6 +511,11 @@ describe("getHeaders", () => {
 
 describe("getBody", () => {
     describe("Valid body", () => {
+        const jsonBody = {
+            username: "John",
+            password: "secret",
+        }
+
         const testCases = [
             {
                 description: "Text body",
@@ -526,38 +531,42 @@ describe("getBody", () => {
                 description: "JSON body with content-type missing",
                 request: new Request("http://example.com/auth/credentials", {
                     method: "POST",
-                    body: JSON.stringify({
-                        username: "John",
-                        password: "secret",
-                    }),
+                    body: JSON.stringify(jsonBody),
                 }),
                 config: {},
-                expected: JSON.stringify({
-                    username: "John",
-                    password: "secret",
-                }),
+                expected: JSON.stringify(jsonBody),
             },
             {
                 description: "JSON body without schema",
                 request: new Request("http://example.com/auth/credentials", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({
-                        username: "John",
-                        password: "secret",
-                    }),
+                    body: JSON.stringify(jsonBody),
                 }),
                 config: {},
-                expected: {
-                    username: "John",
-                    password: "secret",
-                },
+                expected: jsonBody,
             },
             {
                 description: "JSON body with schema",
                 request: new Request("http://example.com/auth/credentials", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(jsonBody),
+                }),
+                config: {
+                    schemas: {
+                        body: z.object({
+                            username: z.string(),
+                            password: z.string(),
+                        }),
+                    },
+                },
+                expected: jsonBody,
+            },
+            {
+                description: "JSON body without content-type and with schema",
+                request: new Request("http://example.com/auth/credentials", {
+                    method: "POST",
                     body: JSON.stringify({
                         username: "John",
                         password: "secret",
@@ -571,7 +580,7 @@ describe("getBody", () => {
                         }),
                     },
                 },
-                expected: { username: "John", password: "secret" },
+                expected: jsonBody,
             },
         ]
 


### PR DESCRIPTION
## Description

This pull request updates the `getBody` function to **clone the original request** before parsing its body. This prevents the raw request stream from being consumed prematurely and allows users to **read the body multiple times** within their endpoint handlers.  

Additionally, all requests whose endpoints define a Zod schema are now automatically parsed using the `request.json()` function, ensuring consistent and type-safe body validation.

> [!NOTE]  
> By default, a request body can only be read once. Attempting to read it multiple times without cloning will result in an error because the stream has already been consumed.

### Example

```ts
const signIn = createEndpoint(
  "POST",
  "/auth/credentials",
  async (request, ctx) => {
    /**
     * The body is not used in this example, but we ensure
     * that the request will be cloned by the getBody function.
     */
    const json = await request.json()

    /*
     * The body parsed based on the Zod schema defined
     * in the endpoint configuration.
     */
    const { body } = ctx
    return Response.json({ message: "Get user", body }, { status: 200 })
  },
  {
    schemas: {
      body: z.object({
        username: z.string(),
        password: z.string(),
      }),
    },
  }
)
