### PR TITLE
feat(core): expose `route`, `method` and `url` properties in context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Per-package version history is maintained inside each package’s own `CHANGELOG
 
 ## [Unreleased]
 
+### Added
+
+- Added the `route`, `method`, and `url` properties to the `context` object for both route handlers and middlewares per endpoint to access extensive metadata related to the incoming request. [#19](https://github.com/aura-stack-ts/router/pull/19).
+
 ### Changed
 
 - Moved the `request` property into the `context` object for both route handlers and middlewares (per endpoint and global). [#18](https://github.com/aura-stack-ts/router/pull/18).

--- a/src/router.ts
+++ b/src/router.ts
@@ -110,6 +110,9 @@ const handleRequest = async (method: HTTPMethod, request: Request, config: Route
             headers,
             body,
             request: globalRequest,
+            url,
+            method: globalRequest.method,
+            route: endpoint.route,
         }
         context = await executeMiddlewares(context, endpoint.config.middlewares)
         const response = await endpoint.handler(context)

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,9 @@ export interface RequestContext<RouteParams = Record<string, string>, Config ext
     body: ContextBody<Config["schemas"]>["body"]
     searchParams: ContextSearchParams<Config["schemas"]>["searchParams"]
     request: Request
+    url: URL
+    method: HTTPMethod
+    route: RoutePattern
 }
 
 /**

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -393,4 +393,22 @@ describe("createEndpoint", () => {
             })
         })
     })
+
+    describe("With method, route, and url", () => {
+        const endpont = createEndpoint("GET", "/users", async (ctx) => {
+            return Response.json({ method: ctx.method, route: ctx.route, url: ctx.url })
+        })
+
+        const { GET } = createRouter([endpont])
+
+        test("Access method, route, and url from context", async ({ expect }) => {
+            const get = await GET(new Request("https://example.com/users?id=123"))
+            expect(get.ok).toBe(true)
+            expect(await get.json()).toEqual({
+                method: "GET",
+                route: "/users",
+                url: "https://example.com/users?id=123",
+            })
+        })
+    })
 })

--- a/test/type.test-d.ts
+++ b/test/type.test-d.ts
@@ -11,6 +11,7 @@ import type {
     RouteEndpoint,
     InferMethod,
     EndpointSchemas,
+    HTTPMethod,
 } from "../src/types.js"
 import type { ZodObject, ZodString } from "zod"
 
@@ -302,6 +303,9 @@ describe("RequestContext", () => {
         body: undefined
         searchParams: URLSearchParams
         request: Request
+        url: URL
+        method: HTTPMethod
+        route: RoutePattern
     }>()
 
     expectTypeOf<RequestContext<{ oauth: string }>>().toEqualTypeOf<{
@@ -310,6 +314,9 @@ describe("RequestContext", () => {
         body: undefined
         searchParams: URLSearchParams
         request: Request
+        url: URL
+        method: HTTPMethod
+        route: RoutePattern
     }>()
 
     expectTypeOf<RequestContext<{ oauth: string; provider: string }>>().toEqualTypeOf<{
@@ -318,6 +325,9 @@ describe("RequestContext", () => {
         body: undefined
         searchParams: URLSearchParams
         request: Request
+        url: URL
+        method: HTTPMethod
+        route: RoutePattern
     }>()
 
     expectTypeOf<
@@ -335,6 +345,9 @@ describe("RequestContext", () => {
         body: { username: string; password: string }
         searchParams: URLSearchParams
         request: Request
+        url: URL
+        method: HTTPMethod
+        route: RoutePattern
     }>()
 
     expectTypeOf<
@@ -352,6 +365,9 @@ describe("RequestContext", () => {
         body: undefined
         searchParams: { code: string; state: string }
         request: Request
+        url: URL
+        method: HTTPMethod
+        route: RoutePattern
     }>()
 
     expectTypeOf<
@@ -370,6 +386,9 @@ describe("RequestContext", () => {
         body: { username: string; password: string }
         searchParams: { code: string; state: string }
         request: Request
+        url: URL
+        method: HTTPMethod
+        route: RoutePattern
     }>()
 
     expectTypeOf<
@@ -388,6 +407,9 @@ describe("RequestContext", () => {
         body: { username: string; password: string }
         searchParams: { code: string; state: string }
         request: Request
+        url: URL
+        method: HTTPMethod
+        route: RoutePattern
     }>()
 })
 


### PR DESCRIPTION
## Description

This pull request exposes the `route`, `method`, and `url` properties in the context object for route handlers and per-endpoint middlewares.  This enhancement expands the available context information, giving the API a richer and more expressive set of properties to work with when handling requests.

These new properties allow developers to more easily access routing metadata without manually parsing or passing additional values through the workflow.
