### PR TITLE
chore: add `prepublish` script in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:bench": "vitest --run bench",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf dist",
-    "clean:cts": "rm -rf dist/*.cts"
+    "clean:cts": "rm -rf dist/*.cts",
+    "prepublish": "pnpm clean:cts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

This pull request adds the `prepublish` script to the `package.json`, which executes the `clean:cts` script to remove unnecessary `.d.cts` type files generated for CommonJS.  Since the project uses ES Modules, these files are not needed and only add extra weight to the final package.

Additionally, the previous published version mistakenly included these `.d.cts` files, even though they should not be part of the final build.  With this new script, we ensure that `.d.cts` files are always removed before publishing a new version of the package.
