### PR TITLE
feat(router): add detailed error messages for failed Zod schemas

### DIFF
--- a/src/assert.ts
+++ b/src/assert.ts
@@ -1,4 +1,4 @@
-import { RouterError } from "./error.js"
+import { InvalidZodSchemaError, RouterError } from "./error.js"
 import type { RouteHandler, HTTPMethod, RoutePattern } from "./types.js"
 
 const supportedMethods = new Set<HTTPMethod>(["GET", "POST", "DELETE", "PUT", "PATCH", "OPTIONS", "HEAD", "TRACE", "CONNECT"])
@@ -66,4 +66,18 @@ export const isValidHandler = (handler: unknown): handler is RouteHandler<any, a
  */
 export const isRouterError = (error: unknown): error is RouterError => {
     return error instanceof RouterError
+}
+
+export const isObject = (value: unknown): value is Record<string, unknown> => {
+    return typeof value === "object" && value !== null && value !== undefined && !Array.isArray(value)
+}
+
+/**
+ * Checks if the provided error is an instance of InvalidZodSchemaError.
+ *
+ * @param error the error to check
+ * @returns true if the error is an instance of InvalidZodSchemaError, false otherwise.
+ */
+export const isInvalidZodSchemaError = (error: unknown): error is InvalidZodSchemaError => {
+    return error instanceof InvalidZodSchemaError
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -80,3 +80,16 @@ export class RouterError extends AuraStackRouterError {
         this.name = name ?? "RouterError"
     }
 }
+
+export class InvalidZodSchemaError {
+    
+    public readonly status: number
+    public readonly statusText: StatusCode
+    public readonly errors: Record<string, string>
+
+    constructor(type: StatusCode, errors: Record<string, string>) {
+        this.status = statusCode[type]
+        this.statusText = statusText[type]
+        this.errors = errors
+    }
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,5 +1,5 @@
 import { RouterError, statusText } from "./error.js"
-import { isRouterError, isSupportedMethod } from "./assert.js"
+import { isInvalidZodSchemaError, isRouterError, isSupportedMethod } from "./assert.js"
 import { executeGlobalMiddlewares, executeMiddlewares } from "./middlewares.js"
 import { getBody, getHeaders, getRouteParams, getSearchParams } from "./context.js"
 import type { GetHttpHandlers, GlobalContext, HTTPMethod, RouteEndpoint, RoutePattern, RouterConfig } from "./types.js"
@@ -75,6 +75,17 @@ const handleError = async (error: unknown, request: Request, config: RouterConfi
                 { status: 500, statusText: statusText.INTERNAL_SERVER_ERROR }
             )
         }
+    }
+    if (isInvalidZodSchemaError(error)) {
+        const { errors, status, statusText } = error
+        return Response.json(
+            {
+                message: "Invalid request data",
+                error: "validation_error",
+                details: errors,
+            },
+            { status, statusText }
+        )
     }
     if (isRouterError(error)) {
         const { message, status, statusText } = error

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -116,7 +116,7 @@ describe("createEndpoint", () => {
                     })
                 )
                 expect(post.status).toBe(422)
-                expect(await post.json()).toEqual({ message: "Invalid request body" })
+                expect(await post.json()).toMatchObject({ error: "validation_error", details: {} })
                 expect(post.statusText).toBe("UNPROCESSABLE_ENTITY")
             })
         })
@@ -150,7 +150,7 @@ describe("createEndpoint", () => {
 
             test("With invalid searchParams", async ({ expect }) => {
                 const get = await GET(new Request("https://example.com/auth/google?state=123abc", { method: "GET" }))
-                expect(await get.json()).toEqual({ message: "Invalid search parameters" })
+                expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
                 expect(get.status).toBe(422)
                 expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
             })
@@ -204,7 +204,7 @@ describe("createEndpoint", () => {
                 const get = await GET(new Request("https://example.com/signIn/facebook"))
                 expect(get.status).toBe(422)
                 expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
-                expect(await get.json()).toEqual({ message: "Invalid route parameters" })
+                expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
             })
 
             test("With inferred params", async ({ expect }) => {
@@ -217,7 +217,7 @@ describe("createEndpoint", () => {
                 const get = await GET(new Request("https://example.com/type/invalid"))
                 expect(get.status).toBe(422)
                 expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
-                expect(await get.json()).toEqual({ message: "Invalid route parameters" })
+                expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
             })
         })
     })

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -94,7 +94,7 @@ describe("createRouter", () => {
                 })
             )
             expect(get.status).toBe(422)
-            expect(await get.json()).toEqual({ message: "Invalid search parameters" })
+            expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
         })
 
         test("Sign-in handler with missing route param", async () => {
@@ -169,7 +169,7 @@ describe("createRouter", () => {
                     }),
                 })
             )
-            expect(await post.json()).toEqual({ message: "Invalid request body" })
+            expect(await post.json()).toMatchObject({ error: "validation_error", details: {} })
             expect(post.status).toBe(422)
         })
     })


### PR DESCRIPTION
## Description

This pull request improves validation error messages for Zod schemas used to parse `searchParams`, `params`, and `body` within endpoint definitions created via `createEndpoint` or `createEndpointConfig`.

Previously, validation failures returned a generic and low-context error message. With this update, the response now provides structured and detailed information about which fields failed validation and why, making debugging and client-side handling significantly easier.

**Before**

```json
{
  "message": "Invalid param"
}

```

**Now**

```json
{
  "message": "Invalid request data",
  "error": "validation_error",
  "details": {
    "user.username": "Invalid ...",
    "user.password": "Invalid ..."
  }
}
```


This enhancement delivers clearer feedback, improves developer experience, and enables more precise error handling on the consumer side.