### PR TITLE
feat(router): introduce headers builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,16 @@
       "import": "./dist/error.js",
       "require": "./dist/error.cjs"
     },
+    "./headers": {
+      "types": "./dist/headers.d.ts",
+      "import": "./dist/headers.js",
+      "require": "./dist/headers.cjs"
+    },
+    "./cookie": {
+      "types": "./dist/cookie.d.ts",
+      "import": "./dist/cookie.js",
+      "require": "./dist/cookie.cjs"
+    },
     "./types": "./dist/types.d.ts"
   },
   "devDependencies": {
@@ -73,5 +83,8 @@
     "vitest": "^3.2.4",
     "zod": "^4.1.11"
   },
-  "packageManager": "pnpm@10.15.0"
+  "packageManager": "pnpm@10.15.0",
+  "dependencies": {
+    "cookie": "^1.1.1"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      cookie:
+        specifier: ^1.1.1
+        version: 1.1.1
     devDependencies:
       prettier:
         specifier: ^3.6.2
@@ -1284,6 +1288,10 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1874,6 +1882,7 @@ packages:
   next@16.0.7:
     resolution: {integrity: sha512-3mBRJyPxT4LOxAJI6IsXeFtKfiJUbjCLgvXO02fV8Wy/lIhPvP94Fe7dGhUgHXcQy4sSuYwQNcOLhIfOm0rL0A==}
     engines: {node: '>=20.9.0'}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -3479,6 +3488,8 @@ snapshots:
   confbox@0.1.8: {}
 
   consola@3.4.2: {}
+
+  cookie@1.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,6 +2,7 @@ import { type ZodError } from "zod"
 import { isSupportedBodyMethod } from "./assert.js"
 import { InvalidZodSchemaError, RouterError } from "./error.js"
 import type { EndpointConfig, ContextSearchParams, ContentType } from "./types.js"
+import { SerializeOptions } from "cookie"
 
 /**
  * @experimental
@@ -96,55 +97,6 @@ export const getSearchParams = <Config extends EndpointConfig>(
         return parsed.data
     }
     return new URLSearchParams(route.searchParams.toString())
-}
-
-/**
- * Extracts headers from the given Request object and returns them as a Headers instance.
- *
- * @param request - The Request object from which to extract headers.
- * @returns A Headers instance containing all headers from the request.
- * @example
- * const request = new Request("https://example.com/api", {
- *   headers: {
- *     "Content-Type": "application/json",
- *     "Authorization": "Bearer token",
- *   },
- * });
- * const headers = getHeaders(request);
- */
-export const getHeaders = (request: Request): Headers => {
-    return new Headers(request.headers)
-}
-
-export class HeadersBuilder {
-    private headers: Headers
-
-    constructor(initialHeaders?: HeadersInit) {
-        this.headers = new Headers(initialHeaders)
-    }
-
-    set(name: string, value: string): HeadersBuilder {
-        this.headers.set(name, value)
-        return this
-    }
-
-    setCookie(name: string, value: string): HeadersBuilder {
-        this.headers.append("Set-Cookie", `${name}=${value}`)
-        return this
-    }
-
-    remove(name: string): HeadersBuilder {
-        this.headers.delete(name)
-        return this
-    }
-
-    get(name: string): string | null {
-        return this.headers.get(name)
-    }
-
-    toHeaders(): Headers {
-        return new Headers(this.headers)
-    }
 }
 
 /**

--- a/src/context.ts
+++ b/src/context.ts
@@ -116,6 +116,37 @@ export const getHeaders = (request: Request): Headers => {
     return new Headers(request.headers)
 }
 
+export class HeadersBuilder {
+    private headers: Headers
+
+    constructor(initialHeaders?: HeadersInit) {
+        this.headers = new Headers(initialHeaders)
+    }
+
+    set(name: string, value: string): HeadersBuilder {
+        this.headers.set(name, value)
+        return this
+    }
+
+    setCookie(name: string, value: string): HeadersBuilder {
+        this.headers.append("Set-Cookie", `${name}=${value}`)
+        return this
+    }
+
+    remove(name: string): HeadersBuilder {
+        this.headers.delete(name)
+        return this
+    }
+
+    get(name: string): string | null {
+        return this.headers.get(name)
+    }
+
+    toHeaders(): Headers {
+        return new Headers(this.headers)
+    }
+}
+
 /**
  * Extracts and parses the body of a Request object based on its Content-Type header.
  *

--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -1,0 +1,5 @@
+/**
+ * @module cookie
+ * Re-exports all exports from the 'cookie' package.
+ */
+export * from "cookie"

--- a/src/error.ts
+++ b/src/error.ts
@@ -82,7 +82,6 @@ export class RouterError extends AuraStackRouterError {
 }
 
 export class InvalidZodSchemaError {
-    
     public readonly status: number
     public readonly statusText: StatusCode
     public readonly errors: Record<string, string>

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -1,0 +1,47 @@
+import { SerializeOptions, serialize, parse, Cookies, parseSetCookie } from "cookie"
+
+/**
+ * A builder class for constructing and manipulating HTTP headers.
+ * It includes methods to set, delete, and retrieve headers, as well as
+ * manage cookies within the headers.
+ */
+export class HeadersBuilder {
+    private headers: Headers
+
+    constructor(initialHeaders?: HeadersInit) {
+        this.headers = new Headers(initialHeaders)
+    }
+
+    setHeader(name: string, value: string): HeadersBuilder {
+        this.headers.set(name, value)
+        return this
+    }
+
+    setCookie(name: string, value: string, options?: SerializeOptions): HeadersBuilder {
+        this.headers.append("Set-Cookie", serialize(name, value, options))
+        return this
+    }
+
+    getHeader(name: string): string | null {
+        return this.headers.get(name)
+    }
+
+    getCookie(name: string): string | undefined {
+        const cookies = parse(this.headers.get("cookie") ?? "")
+        return cookies[name]
+    }
+
+    getSetCookie(name: string): string | undefined {
+        const cookies = this.headers.getSetCookie()
+        const cookie = cookies.find((cookie) => cookie.startsWith(name + "="))
+        return cookie ? parseSetCookie(cookie).value : undefined
+    }
+
+    toHeaders(): Headers {
+        return new Headers(this.headers)
+    }
+
+    toCookies(): Cookies {
+        return parse(this.headers.get("cookie") ?? "")
+    }
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,7 +1,8 @@
 import { RouterError, statusText } from "./error.js"
-import { isInvalidZodSchemaError, isRouterError, isSupportedMethod } from "./assert.js"
+import { HeadersBuilder } from "./headers.js"
+import { getBody, getRouteParams, getSearchParams } from "./context.js"
 import { executeGlobalMiddlewares, executeMiddlewares } from "./middlewares.js"
-import { getBody, getHeaders, getRouteParams, getSearchParams, HeadersBuilder } from "./context.js"
+import { isInvalidZodSchemaError, isRouterError, isSupportedMethod } from "./assert.js"
 import type { GetHttpHandlers, GlobalContext, HTTPMethod, RouteEndpoint, RoutePattern, RouterConfig } from "./types.js"
 
 interface TrieNode {

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,7 +1,7 @@
 import { RouterError, statusText } from "./error.js"
 import { isInvalidZodSchemaError, isRouterError, isSupportedMethod } from "./assert.js"
 import { executeGlobalMiddlewares, executeMiddlewares } from "./middlewares.js"
-import { getBody, getHeaders, getRouteParams, getSearchParams } from "./context.js"
+import { getBody, getHeaders, getRouteParams, getSearchParams, HeadersBuilder } from "./context.js"
 import type { GetHttpHandlers, GlobalContext, HTTPMethod, RouteEndpoint, RoutePattern, RouterConfig } from "./types.js"
 
 interface TrieNode {
@@ -116,7 +116,7 @@ const handleRequest = async (method: HTTPMethod, request: Request, config: Route
         const dynamicParams = getRouteParams(params, endpoint.config)
         const body = await getBody(globalRequestContext.request, endpoint.config)
         const searchParams = getSearchParams(globalRequestContext.request.url, endpoint.config)
-        const headers = getHeaders(globalRequestContext.request)
+        const headers = new HeadersBuilder(globalRequestContext.request.headers)
         let context = {
             params: dynamicParams,
             searchParams,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import { type ZodObject, z } from "zod"
 import { RouterError } from "./error.js"
+import { HeadersBuilder } from "./context.js"
 
 /**
  * Route pattern must start with a slash and can contain parameters prefixed with a colon.
@@ -114,7 +115,7 @@ export type ContextParams<Schemas extends EndpointConfig["schemas"], Default = R
  */
 export interface RequestContext<RouteParams = Record<string, string>, Config extends EndpointConfig = EndpointConfig> {
     params: ContextParams<Config["schemas"], RouteParams>["params"]
-    headers: Headers
+    headers: HeadersBuilder
     body: ContextBody<Config["schemas"]>["body"]
     searchParams: ContextSearchParams<Config["schemas"]>["searchParams"]
     request: Request

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { type ZodObject, z } from "zod"
 import { RouterError } from "./error.js"
-import { HeadersBuilder } from "./context.js"
+import { HeadersBuilder } from "./headers.js"
 
 /**
  * Route pattern must start with a slash and can contain parameters prefixed with a colon.

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,7 +1,8 @@
 import { z } from "zod/v4"
 import { describe, expectTypeOf, test } from "vitest"
 import { createNode, insert, search } from "../src/router.js"
-import { getRouteParams, getSearchParams, getHeaders, getBody } from "../src/context.js"
+import { getRouteParams, getSearchParams, getBody } from "../src/context.js"
+import { HeadersBuilder } from "../src/headers.js"
 import type { RouteEndpoint } from "../src/types.js"
 
 describe("getRouteParams", () => {
@@ -411,19 +412,19 @@ describe("getSearchParams", () => {
     })
 })
 
-describe("getHeaders", () => {
+describe("HeadersBuilder", () => {
     const testCases = [
         {
             description: "No headers",
             request: new Request("http://example.com"),
-            expected: new Headers({}),
+            expected: new HeadersBuilder({}),
         },
         {
             description: "Single header",
             request: new Request("http://example.com", {
                 headers: { Authorization: "Bearer token" },
             }),
-            expected: new Headers({ Authorization: "Bearer token" }),
+            expected: new HeadersBuilder({ Authorization: "Bearer token" }),
         },
         {
             description: "Multiple headers",
@@ -433,7 +434,7 @@ describe("getHeaders", () => {
                     Accept: "application/json",
                 },
             }),
-            expected: new Headers({
+            expected: new HeadersBuilder({
                 "Content-Type": "application/json",
                 Accept: "application/json",
             }),
@@ -441,10 +442,10 @@ describe("getHeaders", () => {
     ]
     for (const { description, request, expected } of testCases) {
         test.concurrent(description, ({ expect }) => {
-            const headers = getHeaders(request)
-            expect(headers instanceof Headers).toBe(true)
+            const headers = new HeadersBuilder(request.headers)
+            expect(headers instanceof HeadersBuilder).toBe(true)
             expect(headers).toBeDefined()
-            expect(headers).toBeInstanceOf(Headers)
+            expect(headers).toBeInstanceOf(HeadersBuilder)
             expect(headers).toEqual(expected)
         })
     }

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -439,6 +439,19 @@ describe("HeadersBuilder", () => {
                 Accept: "application/json",
             }),
         },
+        {
+            description: "",
+            request: new Request("http://example.com", {
+                headers: new HeadersBuilder({
+                    "Content-Type": "application/json",
+                })
+                    .setCookie("sessionId", "abc123", { httpOnly: true, secure: true })
+                    .toHeaders(),
+            }),
+            expected: new HeadersBuilder({
+                "Content-Type": "application/json",
+            }).setCookie("sessionId", "abc123", { httpOnly: true, secure: true }),
+        },
     ]
     for (const { description, request, expected } of testCases) {
         test.concurrent(description, ({ expect }) => {

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -277,7 +277,7 @@ describe("createEndpoint", () => {
                 "GET",
                 "/headers",
                 (ctx) => {
-                    const headers = Object.fromEntries(ctx.headers.entries())
+                    const headers = Object.fromEntries(ctx.headers.toHeaders().entries())
                     return Response.json({ headers })
                 },
                 {

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -283,7 +283,7 @@ describe("createEndpoint", () => {
                 {
                     middlewares: [
                         (ctx) => {
-                            ctx.headers.set("Authorization", "Bearer token")
+                            ctx.headers.setHeader("Authorization", "Bearer token")
                             return ctx
                         },
                     ],

--- a/test/middlewares.test.ts
+++ b/test/middlewares.test.ts
@@ -1,5 +1,6 @@
 import z from "zod"
 import { describe, expect, test } from "vitest"
+import { HeadersBuilder } from "../src/headers.js"
 import { executeGlobalMiddlewares, executeMiddlewares } from "../src/middlewares.js"
 import type { GlobalMiddlewareContext, MiddlewareFunction, RequestContext } from "../src/types.js"
 
@@ -84,20 +85,20 @@ describe("executeMiddlewares", () => {
         const middlewares: MiddlewareFunction[] = [
             async (ctx) => {
                 ctx.searchParams.set("code", "123abc")
-                ctx.headers.set("Content-Type", "application/json")
+                ctx.headers.setHeader("Content-Type", "application/json")
                 return ctx
             },
         ]
         const ctx = await executeMiddlewares(
             {
                 searchParams: new URL("https://example.com").searchParams,
-                headers: new Headers(),
+                headers: new HeadersBuilder(),
                 request: new Request("https://example.com"),
             } as RequestContext,
             middlewares
         )
         expect(ctx.searchParams.get("code")).toBe("123abc")
-        expect(ctx.headers.get("Content-Type")).toBe("application/json")
+        expect(ctx.headers.getHeader("Content-Type")).toBe("application/json")
     })
 
     test.concurrent("Two middlewares with searchParams and headers context", async ({ expect }) => {
@@ -109,21 +110,21 @@ describe("executeMiddlewares", () => {
             },
             async (ctx) => {
                 ctx.searchParams.set("state", "abc")
-                ctx.headers.set("Authorization", "Bearer token")
+                ctx.headers.setHeader("Authorization", "Bearer token")
                 return ctx
             },
         ]
         const ctx = await executeMiddlewares(
             {
                 searchParams: new URL("https://example.com").searchParams,
-                headers: new Headers(),
+                headers: new HeadersBuilder(),
                 request: new Request("https://example.com"),
             } as RequestContext,
             middlewares
         )
         expect(ctx.searchParams.get("code")).toBe("123abc")
         expect(ctx.searchParams.get("state")).toBe("abc")
-        expect(ctx.headers.get("Authorization")).toBe("Bearer token")
+        expect(ctx.headers.getHeader("Authorization")).toBe("Bearer token")
     })
 
     test.concurrent("Invalid middleware", async ({ expect }) => {
@@ -132,7 +133,7 @@ describe("executeMiddlewares", () => {
             executeMiddlewares(
                 {
                     searchParams: new URL("https://example.com").searchParams,
-                    headers: new Headers(),
+                    headers: new HeadersBuilder(),
                     request: new Request("https://example.com"),
                 } as RequestContext,
                 middlewares
@@ -143,12 +144,12 @@ describe("executeMiddlewares", () => {
     test.concurrent("No middleware", async ({ expect }) => {
         const ctx = await executeMiddlewares({
             searchParams: new URL("https://example.com").searchParams,
-            headers: new Headers(),
+            headers: new HeadersBuilder(),
             request: new Request("https://example.com"),
         } as RequestContext)
         expect(ctx.searchParams.get("code")).toBe(null)
         expect(ctx.searchParams.get("state")).toBe(null)
-        expect(ctx.headers.get("Content-Type")).toBe(null)
+        expect(ctx.headers.getHeader("Content-Type")).toBe(null)
     })
 
     test.concurrent("Middleware with schema", async ({ expect }) => {
@@ -167,7 +168,7 @@ describe("executeMiddlewares", () => {
 
         const ctx = await executeMiddlewares(
             {
-                headers: new Headers(),
+                headers: new HeadersBuilder(),
                 searchParams: {
                     code: "123abc",
                     state: "xyz",

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -4,6 +4,7 @@ import { RouterError } from "../src/error.js"
 import { createRouter } from "../src/router.js"
 import { isRouterError } from "../src/assert.js"
 import { createEndpoint, createEndpointConfig } from "../src/endpoint.js"
+import { HeadersBuilder } from "../src/headers.js"
 
 describe("createRouter", () => {
     describe("OAuth endpoints", () => {
@@ -17,7 +18,7 @@ describe("createRouter", () => {
         const sessionConfig = createEndpointConfig({
             middlewares: [
                 (ctx) => {
-                    ctx.headers.set("session-token", "123abc-token")
+                    ctx.headers.setCookie("session-token", "123abc-token")
                     return ctx
                 },
             ],
@@ -111,7 +112,7 @@ describe("createRouter", () => {
             expect(get.status).toBe(200)
             expect(get.ok).toBeTruthy()
             expect(await get.json()).toEqual({ message: "Get user session" })
-            expect(get.headers.get("session-token")).toBe("123abc-token")
+            expect(new HeadersBuilder(get.headers).getSetCookie("session-token")).toBe("123abc-token")
         })
 
         test("Credentials handler", async () => {

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -40,7 +40,7 @@ describe("createRouter", () => {
             "GET",
             "/auth/session",
             (ctx) => {
-                const headers = ctx.headers
+                const headers = ctx.headers.toHeaders()
                 return Response.json({ message: "Get user session" }, { status: 200, headers })
             },
             sessionConfig
@@ -238,11 +238,11 @@ describe("createRouter", () => {
 
     describe("With global middlewares", () => {
         const session = createEndpoint("GET", "/session", async (ctx) => {
-            return Response.json({ message: "Get user session" }, { status: 200, headers: ctx.headers })
+            return Response.json({ message: "Get user session" }, { status: 200, headers: ctx.headers.toHeaders() })
         })
 
         const signIn = createEndpoint("POST", "/auth/:oauth", async (ctx) => {
-            return Response.json({ message: "Sign in with OAuth" }, { status: 200, headers: ctx.headers })
+            return Response.json({ message: "Sign in with OAuth" }, { status: 200, headers: ctx.headers.toHeaders() })
         })
 
         describe("Add headers middleware", async () => {

--- a/test/type.test-d.ts
+++ b/test/type.test-d.ts
@@ -1,4 +1,5 @@
 import { describe, expectTypeOf } from "vitest"
+import { HeadersBuilder } from "../src/headers.js"
 import type {
     RoutePattern,
     GetRouteParams,
@@ -243,7 +244,7 @@ describe("ContextBody", () => {
 describe("RequestContext", () => {
     type Context<T extends Record<string, unknown>> = Prettify<
         {
-            headers: Headers
+            headers: HeadersBuilder
             request: Request
             url: URL
             method: HTTPMethod


### PR DESCRIPTION
## Description

This pull request introduces the `HeadersBuilder` class to simplify and standardize HTTP header management through an imperative API.  The class provides a convenient set of methods for common header and cookie operations, including:

- `setHeader`
- `getHeader`
- `setCookie`
- `getCookie`
- `getSetCookie`

`HeadersBuilder` internally uses the `cookie` package for cookie parsing and decoding, ensuring correct and reliable cookie handling.

The class is exposed through the `/headers` entry point.   Additionally, the `cookie` package is re-exported via the `/cookie` entry point for direct consumption when lower-level cookie utilities are needed.
