### PR TITLE
chore(release): bump package version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ Per-package version history is maintained inside each package’s own `CHANGELOG
 
 ---
 
+## [0.5.0] - 2025-12-22
+
+### Added
+
+- Added `HeadersBuilder` class for HTTP headers management with methods for common operations: `setHeader`, `getHeader`, `setCookie`, `getCookie`, and `getSetCookie`. Exposed via `/headers` entry point. [#26](https://github.com/aura-stack-ts/router/pull/26).
+
+- Added cookie package via `/cookie` entry point for direct cookie management using the [cookie package](https://www.npmjs.com/package/cookie). [#26](https://github.com/aura-stack-ts/router/pull/26).
+
+### Changed
+
+- Updated the default error message for failed Zod schema validation in `searchParams`, `params`, and `body` context values. Now returns a detailed object with `message`, `error`, and `details` fields. [#25](https://github.com/aura-stack-ts/router/pull/25).
+
+---
+
 ## [0.4.0] - 2025-12-09
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/router",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "description": "A lightweight TypeScript library for building, managing, and validating API routes and endpoints in Node.js applications.",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { createEndpoint, createEndpointConfig } from "./endpoint.js"
 export { createRouter } from "./router.js"
-export { isRouterError } from "./assert.js"
+export { isRouterError, isInvalidZodSchemaError } from "./assert.js"
 export { RouterError, statusCode, statusText } from "./error.js"
+export { HeadersBuilder } from "./headers.js"
 export type * from "./types.js"


### PR DESCRIPTION
## Description

This pull request bumps the package version to `v0.5.0`.   The new release includes improvements to the default behavior when Zod schema validation fails for `searchParams`, `params`, and `body` configurations in endpoint definitions created with `createEndpoint` or `createEndpointConfig`.

Additionally, this version introduces the new `HeadersBuilder` class for structured and imperative HTTP header management.

### Related PRs
- #26
- #25
