### PR TITLE
feat(client): introduce client API

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "./types": "./dist/types.d.ts"
   },
   "devDependencies": {
+    "@types/node": "24.6.2",
     "prettier": "^3.6.2",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,11 @@
       "import": "./dist/cookie.js",
       "require": "./dist/cookie.cjs"
     },
+    "./client": {
+      "types": "./dist/client.d.ts",
+      "import": "./dist/client.js",
+      "require": "./dist/client.cjs"
+    },
     "./types": "./dist/types.d.ts"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
     devDependencies:
+      '@types/node':
+        specifier: 24.6.2
+        version: 24.6.2
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -2211,6 +2214,7 @@ packages:
   tar@7.5.1:
     resolution: {integrity: sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,29 +1,32 @@
 import type { Router, InferEndpoints, Client, HTTPMethod, ClientOptions } from "./types.js"
 
-export function createClient<T extends Router<any>>(options: ClientOptions): Client<InferEndpoints<T>> {
+export function createClient<InferRouter extends Router<any>>(options: ClientOptions): Client<InferEndpoints<InferRouter>> {
     const { baseURL, headers: defaultHeaders } = options
-    return new Proxy({}, {
-        get(_, prop) {
-            const method = prop.toString().toUpperCase() as HTTPMethod
-            return async (path: string, ctx?: any) => {
-                const searchParams = new URLSearchParams({ ...ctx?.searchParams })
-                for (const [key, value] of Object.entries(ctx?.params ?? {})) {
-                    path = path.replace(`:${key}`, String(value))
+    return new Proxy(
+        {},
+        {
+            get(_, prop) {
+                const method = prop.toString().toUpperCase() as HTTPMethod
+                return async (path: string, ctx?: any) => {
+                    const searchParams = new URLSearchParams({ ...ctx?.searchParams })
+                    for (const [key, value] of Object.entries(ctx?.params ?? {})) {
+                        path = path.replace(`:${key}`, String(value))
+                    }
+                    const url = new URL(path, baseURL)
+                    url.searchParams.append(searchParams.toString(), "")
+                    const response = await fetch(url.toString(), {
+                        ...ctx,
+                        method,
+                        headers: {
+                            ...(ctx?.body && !(ctx.body instanceof FormData) ? { "Content-Type": "application/json" } : {}),
+                            ...defaultHeaders,
+                            ...ctx?.headers,
+                        },
+                        body: ctx?.body ? (ctx.body instanceof FormData ? ctx.body : JSON.stringify(ctx.body)) : undefined,
+                    })
+                    return response
                 }
-                const url = new URL(path, baseURL)
-                url.searchParams.append(searchParams.toString(), "")
-                const response = await fetch(url.toString(), {
-                    ...ctx,
-                    method,
-                    headers: {
-                        ...(ctx?.body && !(ctx.body instanceof FormData) ? { "Content-Type": "application/json" } : {}),
-                        ...defaultHeaders,
-                        ...ctx?.headers,
-                    },
-                    body: ctx?.body ? (ctx.body instanceof FormData ? ctx.body : JSON.stringify(ctx.body)) : undefined,
-                })
-                return response
-            }
-        },
-    }) as Client<InferEndpoints<T>>
+            },
+        }
+    ) as Client<InferEndpoints<InferRouter>>
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,17 @@
+import type { HTTPMethod, RouterConfig } from "./types.js"
+
+export const createClientHandler = (method: HTTPMethod, config: RouterConfig) => {
+    return async (path: string, ctx?: Record<string, any>) => {
+        const searchParams = new URLSearchParams({ ...ctx?.searchParams })
+        for (const [key, value] of Object.entries(ctx?.params ?? {})) {
+            path = path.replace(`:${key}`, encodeURIComponent(String(value)))
+        }
+        const url = config.baseURL ? `${config.baseURL}${config.basePath ?? ""}${path}` : path
+        const urlWithParams = searchParams.toString() ? `${url}?${searchParams.toString()}` : url
+        return await fetch(urlWithParams, {
+            ...ctx,
+            method,
+            body: ctx?.body ? (ctx.body instanceof FormData ? ctx.body : JSON.stringify(ctx.body)) : undefined,
+        })
+    }
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,21 @@
 import type { Router, InferEndpoints, Client, HTTPMethod, ClientOptions } from "./types.js"
 
+/**
+ * Creates a client API for making requests to the specified router. It provides type-safe methods
+ * based on the router's endpoints.
+ *
+ * @param options - Configuration options for the client, including baseURL and default headers.
+ * @returns A client object with methods corresponding to HTTP methods (GET, POST, etc.).
+ * @example
+ * import { createClient } from "aura-stack/router/client";
+ * import { appRouter } from "./server";
+ *
+ * const client = createClient<typeof appRouter>({
+ *   baseURL: "http://localhost:3000/api",
+ * })
+ *
+ * client.get("/users")
+ */
 export function createClient<InferRouter extends Router<any>>(options: ClientOptions): Client<InferEndpoints<InferRouter>> {
     const { baseURL, headers: defaultHeaders } = options
     return new Proxy(

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,17 +1,45 @@
-import type { HTTPMethod, RouterConfig } from "./types.js"
+import z from "zod"
+import { createEndpoint } from "./endpoint.js"
+import { createRouter } from "./router.js"
+import { Router, InferEndpoints, Client, HTTPMethod } from "./types.js"
 
-export const createClientHandler = (method: HTTPMethod, config: RouterConfig) => {
-    return async (path: string, ctx?: Record<string, any>) => {
-        const searchParams = new URLSearchParams({ ...ctx?.searchParams })
-        for (const [key, value] of Object.entries(ctx?.params ?? {})) {
-            path = path.replace(`:${key}`, encodeURIComponent(String(value)))
-        }
-        const url = config.baseURL ? `${config.baseURL}${config.basePath ?? ""}${path}` : path
-        const urlWithParams = searchParams.toString() ? `${url}?${searchParams.toString()}` : url
-        return await fetch(urlWithParams, {
-            ...ctx,
-            method,
-            body: ctx?.body ? (ctx.body instanceof FormData ? ctx.body : JSON.stringify(ctx.body)) : undefined,
-        })
-    }
+export type ClientOptions = {
+    baseURL: string
+    headers?: Record<string, string>
+}
+
+export function createClient<T extends Router<any>>(options: ClientOptions): Client<InferEndpoints<T>> {
+    const { baseURL, headers: defaultHeaders } = options
+    return new Proxy({} as any, {
+        get(_, prop) {
+            const method = prop.toString().toUpperCase() as HTTPMethod
+            return async (path: string, ctx?: any) => {
+                let finalPath = path
+                if (ctx?.params) {
+                    for (const [key, value] of Object.entries(ctx.params)) {
+                        finalPath = finalPath.replace(`:${key}`, String(value))
+                    }
+                }
+                const url = new URL(finalPath, baseURL)
+                if (ctx?.searchParams) {
+                    for (const [key, value] of Object.entries(ctx.searchParams)) {
+                        if (value !== undefined) url.searchParams.append(key, String(value))
+                    }
+                }
+                const response = await fetch(url.toString(), {
+                    method,
+                    headers: {
+                        ...(ctx?.body && !(ctx.body instanceof FormData) ? { "Content-Type": "application/json" } : {}),
+                        ...defaultHeaders,
+                        ...ctx?.headers,
+                    },
+                    body: ctx?.body ? (ctx.body instanceof FormData ? ctx.body : JSON.stringify(ctx.body)) : undefined,
+                })
+                if (!response.ok) {
+                    throw new Error(`Request failed with status ${response.status}`)
+                }
+                return response.json()
+            }
+        },
+    }) as Client<InferEndpoints<T>>
 }

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,6 +1,7 @@
 import { RouterError } from "./error.js"
 import { isSupportedMethod, isValidHandler, isValidRoute } from "./assert.js"
 import type { EndpointConfig, EndpointSchemas, HTTPMethod, RouteEndpoint, RouteHandler, RoutePattern } from "./types.js"
+import { ZodObject } from "zod"
 
 /**
  * Defines an API endpoint for the router by specifying the HTTP method, route pattern,
@@ -26,8 +27,8 @@ export const createEndpoint = <
     method: Method,
     route: Route,
     handler: RouteHandler<Route, { schemas: Schemas }>,
-    config: EndpointConfig<Route, Schemas> = {}
-): RouteEndpoint<Method, Route, {}> => {
+    config: EndpointConfig<Route, Schemas> = {} as EndpointConfig<Route, Schemas>
+): RouteEndpoint<Method, Route, { schemas?: Schemas }> => {
     if (!isSupportedMethod(method)) {
         throw new RouterError("METHOD_NOT_ALLOWED", `Unsupported HTTP method: ${method}`)
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { createEndpoint, createEndpointConfig } from "./endpoint.js"
 export { createRouter } from "./router.js"
+export { createClient } from "./client.js"
 export { isRouterError, isInvalidZodSchemaError } from "./assert.js"
 export { RouterError, statusCode, statusText } from "./error.js"
 export { HeadersBuilder } from "./headers.js"

--- a/src/router.ts
+++ b/src/router.ts
@@ -3,9 +3,16 @@ import { HeadersBuilder } from "./headers.js"
 import { getBody, getRouteParams, getSearchParams } from "./context.js"
 import { executeGlobalMiddlewares, executeMiddlewares } from "./middlewares.js"
 import { isInvalidZodSchemaError, isRouterError, isSupportedMethod } from "./assert.js"
-import type { GetHttpHandlers, GlobalContext, HTTPMethod, RouteEndpoint, RoutePattern, RouterConfig, Client } from "./types.js"
-import { createClientHandler } from "./client.js"
-
+import type {
+    GetHttpHandlers,
+    GlobalContext,
+    HTTPMethod,
+    RouteEndpoint,
+    RoutePattern,
+    RouterConfig,
+    Client,
+    Router,
+} from "./types.js"
 interface TrieNode {
     statics: Map<string, TrieNode>
     param?: { name: string; node: TrieNode }
@@ -150,9 +157,8 @@ const handleRequest = async (method: HTTPMethod, request: Request, config: Route
 export const createRouter = <const Endpoints extends RouteEndpoint[]>(
     endpoints: Endpoints,
     config: RouterConfig = {}
-): { handlers: GetHttpHandlers<Endpoints>; client: Client<Endpoints> } => {
+): Router<Endpoints> => {
     const root = createNode()
-    const client = {} as Client<Endpoints>
     const server = {} as GetHttpHandlers<Endpoints>
     const methods = new Set<HTTPMethod>()
     for (const endpoint of endpoints) {
@@ -162,13 +168,8 @@ export const createRouter = <const Endpoints extends RouteEndpoint[]>(
     }
     for (const method of methods) {
         server[method as keyof typeof server] = (request: Request) => handleRequest(method, request, config, root)
-        client[method.toLowerCase() as keyof typeof client] = createClientHandler(
-            method,
-            config
-        ) as Client<Endpoints>[keyof Client<Endpoints>]
     }
     return {
         handlers: server,
-        client,
     }
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -3,16 +3,8 @@ import { HeadersBuilder } from "./headers.js"
 import { getBody, getRouteParams, getSearchParams } from "./context.js"
 import { executeGlobalMiddlewares, executeMiddlewares } from "./middlewares.js"
 import { isInvalidZodSchemaError, isRouterError, isSupportedMethod } from "./assert.js"
-import type {
-    GetHttpHandlers,
-    GlobalContext,
-    HTTPMethod,
-    RouteEndpoint,
-    RoutePattern,
-    RouterConfig,
-    Client,
-    Router,
-} from "./types.js"
+import type { GetHttpHandlers, GlobalContext, HTTPMethod, RouteEndpoint, RoutePattern, RouterConfig, Router } from "./types.js"
+
 interface TrieNode {
     statics: Map<string, TrieNode>
     param?: { name: string; node: TrieNode }
@@ -169,7 +161,5 @@ export const createRouter = <const Endpoints extends RouteEndpoint[]>(
     for (const method of methods) {
         server[method as keyof typeof server] = (request: Request) => handleRequest(method, request, config, root)
     }
-    return {
-        handlers: server,
-    }
+    return server
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -295,8 +295,10 @@ export type Client<Defs extends RouteEndpoint[]> = {
     ) => Promise<Response>
 }
 
-export type Router<Endpoints extends RouteEndpoint[]> = {
-    handlers: GetHttpHandlers<Endpoints>,
+declare const endpointsSymbol: unique symbol
+
+export type Router<Endpoints extends RouteEndpoint[]> = GetHttpHandlers<Endpoints> & {
+    readonly [endpointsSymbol]?: Endpoints
 }
 
 export type InferEndpoints<T> = T extends Router<infer E> ? E : never

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import { type ZodObject, z } from "zod"
 import { RouterError } from "./error.js"
 import { HeadersBuilder } from "./headers.js"
+import { type IncomingHttpHeaders } from "http"
 
 /**
  * Route pattern must start with a slash and can contain parameters prefixed with a colon.
@@ -295,7 +296,12 @@ export type Client<Defs extends RouteEndpoint[]> = {
 }
 
 export type Router<Endpoints extends RouteEndpoint[]> = {
-    handlers: GetHttpHandlers<Endpoints>
+    handlers: GetHttpHandlers<Endpoints>,
 }
 
 export type InferEndpoints<T> = T extends Router<infer E> ? E : never
+
+export interface ClientOptions {
+    baseURL: string
+    headers?: IncomingHttpHeaders
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -293,3 +293,9 @@ export type Client<Defs extends RouteEndpoint[]> = {
         ...args: Config extends EndpointSchemas ? [path: T, ctx?: RequestInit] : [path: T, ctx: RequestInit & Config]
     ) => Promise<Response>
 }
+
+export type Router<Endpoints extends RouteEndpoint[]> = {
+    handlers: GetHttpHandlers<Endpoints>
+}
+
+export type InferEndpoints<T> = T extends Router<infer E> ? E : never

--- a/src/types.ts
+++ b/src/types.ts
@@ -291,7 +291,9 @@ export type Find<Defs extends RouteEndpoint[], Met extends HTTPMethod, Path exte
 
 export type Client<Defs extends RouteEndpoint[]> = {
     [M in InferMethod<Defs> as Lowercase<M>]: <T extends ExtractRoutesByMethod<Defs, M>, Config extends Find<Defs, M, T>>(
-        ...args: Config extends EndpointSchemas ? [path: T, ctx?: RequestInit] : [path: T, ctx: RequestInit & Config]
+        ...args: Config extends EndpointSchemas
+            ? [path: T, ctx?: RequestInit]
+            : [path: T, ctx: Omit<RequestInit, "body"> & Config]
     ) => Promise<Response>
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -236,14 +236,6 @@ export interface RouterConfig extends GlobalCtx {
      * }
      */
     onError?: (error: Error | RouterError, request: Request) => Response | Promise<Response>
-    /**
-     * Base URL for the router client to make requests to the server.
-     * This is useful when the server is hosted on a different origin.
-     *
-     * @example
-     * baseURL: "https://api.example.com"
-     */
-    baseURL?: string
 }
 
 /**
@@ -306,6 +298,15 @@ export type Router<Endpoints extends RouteEndpoint[]> = GetHttpHandlers<Endpoint
 export type InferEndpoints<T> = T extends Router<infer E> ? E : never
 
 export interface ClientOptions {
+    /**
+     * Base URL for the router client to make requests to the server.
+     * This is useful when the server is hosted on a different origin.
+     *
+     * baseURL: "https://api.example.com"
+     */
     baseURL: string
+    /**
+     * Default headers to include in every request made by the client.
+     */
     headers?: IncomingHttpHeaders
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -293,7 +293,7 @@ export type Client<Defs extends RouteEndpoint[]> = {
     [M in InferMethod<Defs> as Lowercase<M>]: <T extends ExtractRoutesByMethod<Defs, M>, Config extends Find<Defs, M, T>>(
         ...args: Config extends EndpointSchemas
             ? [path: T, ctx?: RequestInit]
-            : [path: T, ctx: Omit<RequestInit, "body"> & Config]
+            : [path: T, ctx: Prettify<Omit<RequestInit, "body"> & Config>]
     ) => Promise<Response>
 }
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect, vi, beforeEach } from "vitest"
+import { z } from "zod"
+import { createRouter } from "../src/router.js"
+import { createEndpoint } from "../src/endpoint.js"
+import { createClient } from "../src/client.js"
+
+describe("Client", () => {
+    beforeEach(() => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => {
+                return new Response(JSON.stringify({ success: true }), { status: 200 })
+            })
+        )
+    })
+
+    const router = createRouter([
+        createEndpoint("GET", "/users", () => new Response("")),
+        createEndpoint("GET", "/users/:userId", () => new Response(""), {
+            schemas: { params: z.object({ userId: z.string() }) },
+        }),
+        createEndpoint("POST", "/users", () => new Response(""), {
+            schemas: { body: z.object({ name: z.string() }) },
+        }),
+        createEndpoint("DELETE", "/users/:userId", () => new Response(""), {
+            schemas: {
+                params: z.object({ userId: z.string() }),
+                searchParams: z.object({ force: z.string().optional() }),
+            },
+        }),
+    ])
+    const client = createClient<typeof router>({
+        baseURL: "http://api.example.com",
+    })
+
+    test("GET request", async () => {
+        await client.get("/users")
+        expect(fetch).toHaveBeenCalledWith(
+            "http://api.example.com/users",
+            expect.objectContaining({
+                method: "GET",
+            })
+        )
+    })
+
+    test("GET request with dynamic params", async () => {
+        await client.get("/users/:userId", {
+            params: { userId: "123" },
+        })
+        expect(fetch).toHaveBeenCalledWith(
+            "http://api.example.com/users/123",
+            expect.objectContaining({
+                method: "GET",
+            })
+        )
+    })
+
+    test("POST request with search parameters", async () => {
+        await client.post("/users", {
+            body: {
+                name: "Jane Doe",
+            },
+        })
+    })
+
+    test("POST request with body", async () => {
+        const body = { name: "John Doe" }
+        await client.post("/users", { body, headers: { "Content-Type": "application/json" } })
+
+        expect(fetch).toHaveBeenCalledWith(
+            "http://api.example.com/users",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify(body),
+                headers: {
+                    "Content-Type": "application/json",
+                },
+            })
+        )
+    })
+
+    test("DELETE request with search parameters", async () => {
+        await client.delete("/users/:userId", {
+            params: { userId: "456" },
+            searchParams: { force: "true" },
+        })
+
+        expect(fetch).toHaveBeenCalledWith(
+            "http://api.example.com/users/456?force=true",
+            expect.objectContaining({
+                method: "DELETE",
+            })
+        )
+    })
+
+    test("createClient headers merging", async () => {
+        const customClient = createClient<typeof router>({
+            baseURL: "http://api.example.com",
+            headers: { "X-API-KEY": "secret" },
+        })
+
+        await customClient.get("/users", {
+            headers: { "X-Custom": "val" },
+        })
+
+        expect(fetch).toHaveBeenCalledWith(
+            "http://api.example.com/users",
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    "X-API-KEY": "secret",
+                    "X-Custom": "val",
+                }),
+            })
+        )
+    })
+})

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -57,9 +57,11 @@ describe("Client", () => {
 
     test("POST request with search parameters", async () => {
         await client.post("/users", {
-            body: {
-                name: "Jane Doe",
+            headers: {
+                "Content-Type": "application/x-www-form-urlencoded",
             },
+            // @ts-expect-error @todo: add support for different body types
+            body: new URLSearchParams({ name: "Jane Doe" }),
         })
     })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "target": "ES2020",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "moduleDetection": "force",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup"
 
 export default defineConfig({
     entry: ["src"],
-    format: ["esm"],
+    format: ["esm", "cjs"],
     dts: true,
     clean: true,
 })

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup"
 
 export default defineConfig({
     entry: ["src"],
-    format: ["esm", "cjs"],
+    format: ["esm"],
     dts: true,
     clean: true,
 })


### PR DESCRIPTION
## Description

This pull request introduces the **Client API** to access endpoints defined via the `createRouter` function. The Client API is fully powered by **router-based type inference**, enabling type-safe and ergonomic access to all registered endpoints.

The `createClient` function can be accessed from either the **main index** or the **client entry point** of the `@aura-stack/router` package.

```ts
import { createRouter, createClient } from "@aura-stack/router"

const router = createRouter([])
const client = createClient<typeof router>()
```