### PR TITLE
feat(client): support optional `basePath` in `createClient`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -25,12 +25,12 @@ export function createClient<InferRouter extends Router<any>>(options: ClientOpt
                 const method = prop.toString().toUpperCase() as HTTPMethod
                 return async (path: string, ctx?: any) => {
                     const searchParams = new URLSearchParams(ctx?.searchParams)
-                    let interpolatedPath = path
+                    let resolvedPath = `${options.basePath ?? ""}${path}`
                     for (const [key, value] of Object.entries(ctx?.params ?? {})) {
-                        interpolatedPath = interpolatedPath.replace(`:${key}`, String(value))
+                        resolvedPath = resolvedPath.replace(`:${key}`, String(value))
                     }
 
-                    const url = new URL(interpolatedPath, baseURL)
+                    const url = new URL(resolvedPath, baseURL)
                     if (searchParams.size > 0) {
                         url.search = searchParams.toString()
                     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -306,6 +306,10 @@ export interface ClientOptions {
      */
     baseURL: string
     /**
+     * Optional base path to prepend to all request paths made by the client.
+     */
+    basePath?: RoutePattern
+    /**
      * Default headers to include in every request made by the client.
      */
     headers?: IncomingHttpHeaders

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -96,12 +96,12 @@ describe("Client", () => {
     })
 
     test("createClient headers merging", async () => {
-        const customClient = createClient<typeof router>({
+        const client = createClient<typeof router>({
             baseURL: "http://api.example.com",
             headers: { "X-API-KEY": "secret" },
         })
 
-        await customClient.get("/users", {
+        await client.get("/users", {
             headers: { "X-Custom": "val" },
         })
 
@@ -114,5 +114,16 @@ describe("Client", () => {
                 }),
             })
         )
+    })
+
+    test("createClient with basePath", async () => {
+        const client = createClient<typeof router>({
+            baseURL: "http://api.example.com",
+            basePath: "/v1",
+        })
+
+        await client.get("/users")
+
+        expect(fetch).toHaveBeenCalledWith("http://api.example.com/v1/users", expect.objectContaining({}))
     })
 })


### PR DESCRIPTION
## Description

This pull request introduces support for an optional `basePath` option in the `createClient` function.

The new option allows consumers to define a base path that is automatically prefixed to **all requests** made by the client API. This is especially useful when the router is mounted under a sub-path (e.g. `/auth`, `/api`, etc.) without requiring manual path concatenation in every request.

### Example

```ts
import { createRouter } from "@aura-stack/router"
import { createClient } from "@aura-stack/router/client"

const router = createRouter([])

const client = createClient<typeof router>({
  baseURL: "http://localhost:3000",
  basePath: "/auth",
})

// Expected: http://localhost:3000/auth/session
await client.get("/session")
```