### PR TITLE
feat(endpoint): add multi-method support to endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Per-package version history is maintained inside each package’s own `CHANGELOG
 
 ### Added
 
+- Added support for multiple HTTP methods in endpoint definitions via `createEndpoint`. Multiple HTTP methods can now match the same route. [#36](https://github.com/aura-stack-ts/router/pull/36)
+
 - Added support for dynamic headers in `createClient`. Headers can now be returned as an object or a `Promise` resolving to an object. [#33](https://github.com/aura-stack-ts/router/pull/33)
 
 - Added `basePath` option in `createClient` function to define the base path for all requests made to the endpoints. [#30](https://github.com/aura-stack-ts/router/pull/30).

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "cookie": "^1.1.1",
       },
       "devDependencies": {
-        "@types/bun": "latest",
+        "@types/bun": "^1.3.9",
         "@types/node": "24.6.2",
         "prettier": "^3.6.2",
         "tsup": "^8.5.1",

--- a/deno.lock
+++ b/deno.lock
@@ -772,6 +772,7 @@
     ],
     "packageJson": {
       "dependencies": [
+        "npm:@types/bun@^1.3.9",
         "npm:@types/node@24.6.2",
         "npm:cookie@^1.1.1",
         "npm:prettier@^3.6.2",

--- a/docs/src/content/docs/create-endpoint.mdx
+++ b/docs/src/content/docs/create-endpoint.mdx
@@ -162,7 +162,7 @@ The `createEndpoint` function accepts a structured set of parameters that define
 import type { HTTPMethod, RoutePattern, EndpointConfig, RouteHandler } from "@aura-stack/router/types"
 
 interface RouteEndpoint<
-  Method extends HTTPMethod = HTTPMethod,
+  Method extends HTTPMethod | HTTPMethod[] = HTTPMethod | HTTPMethod[],
   Route extends RoutePattern = RoutePattern,
   Config extends EndpointConfig = EndpointConfig,
 > {
@@ -188,7 +188,7 @@ The `method` is a required value in an endpoint definition. It specifies the HTT
 import type { HTTPMethod } from "@aura-stack/router/types"
 
 // Expected: "GET" | "POST" | "DELETE" | "PUT" | "PATCH" | "OPTIONS" | "HEAD" | "TRACE" | "CONNECT"
-export type Methods = HTTPMethod
+export type Methods = HTTPMethod | HTTPMethod[]
 ```
 
 #### `route` [#route]
@@ -678,6 +678,20 @@ const config = createEndpointConfig({
       return ctx
     },
   ],
+})
+```
+
+### With `multiple methods`
+
+`createEndpoint` also supports defining multiple HTTP methods for the same route pattern. This allows handling different methods with the same logic or configuration.
+
+```ts lineNumbers
+const multiMethodEndpoint = createEndpoint(["GET", "POST"], "/multi", async (ctx) => {
+  if (ctx.method === "GET") {
+    return Response.json({ message: "Handled GET request" })
+  } else if (ctx.method === "POST") {
+    return Response.json({ message: "Handled POST request" })
+  }
 })
 ```
 

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -13,7 +13,10 @@ export const supportedProtocols = new Set(["http:", "https:"])
  * @param method - The HTTP method to check.
  * @returns True if the method is supported, false otherwise.
  */
-export const isSupportedMethod = (method: string): method is HTTPMethod => {
+export const isSupportedMethod = (method: string | string[]): method is HTTPMethod => {
+    if (Array.isArray(method)) {
+        return method.every((meth) => supportedMethods.has(meth as HTTPMethod))
+    }
     return supportedMethods.has(method as HTTPMethod)
 }
 

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -13,7 +13,7 @@ export const supportedProtocols = new Set(["http:", "https:"])
  * @param method - The HTTP method to check.
  * @returns True if the method is supported, false otherwise.
  */
-export const isSupportedMethod = (method: string | string[]): method is HTTPMethod => {
+export const isSupportedMethod = (method: string | string[]): method is HTTPMethod | HTTPMethod[] => {
     if (Array.isArray(method)) {
         return method.every((meth) => supportedMethods.has(meth as HTTPMethod))
     }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,6 @@
-import { type ZodError } from "zod"
 import { isSupportedBodyMethod } from "./assert.ts"
 import { InvalidZodSchemaError, RouterError } from "./error.ts"
+import type { ZodError } from "zod"
 import type { EndpointConfig, ContextSearchParams, ContentType } from "./types.ts"
 
 /**

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -19,7 +19,7 @@ import type { EndpointConfig, EndpointSchemas, HTTPMethod, RouteEndpoint, RouteH
  * });
  */
 export const createEndpoint = <
-    const Method extends Uppercase<HTTPMethod>,
+    const Method extends Uppercase<HTTPMethod> | Uppercase<HTTPMethod>[],
     const Route extends RoutePattern,
     const Schemas extends EndpointSchemas,
 >(

--- a/src/router.ts
+++ b/src/router.ts
@@ -44,8 +44,6 @@ export const insert = (root: TrieNode, endpoint: RouteEndpoint) => {
         if (node.endpoints.has(method)) {
             throw new RouterError("BAD_REQUEST", `Duplicate endpoint for ${endpoint?.method} ${endpoint?.route}`)
         }
-    }
-    for (const method of methods) {
         node.endpoints.set(method, endpoint)
     }
 }
@@ -116,10 +114,6 @@ const handleRequest = async (method: HTTPMethod, request: Request, config: Route
             throw new RouterError("METHOD_NOT_ALLOWED", `The HTTP method '${globalRequestContext.request.method}' is not allowed`)
         }
         const { endpoint, params } = search(method, root, pathnameWithBase)
-        const endpointMethods = Array.isArray(endpoint.method) ? endpoint.method : [endpoint.method]
-        if (!endpointMethods.includes(globalRequestContext.request.method)) {
-            throw new RouterError("METHOD_NOT_ALLOWED", `The HTTP method '${globalRequestContext.request.method}' is not allowed`)
-        }
         const dynamicParams = getRouteParams(params, endpoint.config)
         const body = await getBody(globalRequestContext.request, endpoint.config)
         const searchParams = getSearchParams(globalRequestContext.request.url, endpoint.config)

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -176,7 +176,7 @@ describe("createEndpoint", () => {
             const endpoint = createEndpoint(
                 "GET",
                 "/signIn/:oauth",
-                async (ctx) => {
+                (ctx) => {
                     const oauth = ctx.params.oauth
                     return Response.json({ oauth })
                 },
@@ -186,7 +186,7 @@ describe("createEndpoint", () => {
             const inferEndpoint = createEndpoint(
                 "GET",
                 "/type/:typeId",
-                async (ctx) => {
+                (ctx) => {
                     return Response.json({ typeId: ctx.params.typeId })
                 },
                 inferConfig
@@ -399,7 +399,7 @@ describe("createEndpoint", () => {
     })
 
     describe("With method, route, and url", () => {
-        const endpont = createEndpoint("GET", "/users", async (ctx) => {
+        const endpont = createEndpoint("GET", "/users", (ctx) => {
             return Response.json({ method: ctx.method, route: ctx.route, url: ctx.url })
         })
 
@@ -412,6 +412,44 @@ describe("createEndpoint", () => {
                 method: "GET",
                 route: "/users",
                 url: "https://example.com/users?id=123",
+            })
+        })
+    })
+
+    describe("with multiple HTTP methods", () => {
+        const endpoint = createEndpoint(["GET", "POST"], "/items", (ctx) => {
+            return Response.json({ method: ctx.method, route: ctx.route })
+        })
+        const deleteEndpoint = createEndpoint("DELETE", "/items/:id", (ctx) => {
+            return Response.json({ method: ctx.method, route: ctx.route, id: ctx.params.id })
+        })
+        const router = createRouter([endpoint, deleteEndpoint])
+
+        test("Handle GET request", async ({ expect }) => {
+            const get = await router.GET(new Request("https://example.com/items"))
+            expect(get.ok).toBe(true)
+            expect(await get.json()).toEqual({
+                method: "GET",
+                route: "/items",
+            })
+        })
+
+        test("Handle POST request", async ({ expect }) => {
+            const post = await router.POST(new Request("https://example.com/items", { method: "POST" }))
+            expect(post.ok).toBe(true)
+            expect(await post.json()).toEqual({
+                method: "POST",
+                route: "/items",
+            })
+        })
+
+        test("Handle DELETE request with params", async ({ expect }) => {
+            const del = await router.DELETE(new Request("https://example.com/items/123", { method: "DELETE" }))
+            expect(del.ok).toBe(true)
+            expect(await del.json()).toEqual({
+                method: "DELETE",
+                route: "/items/:id",
+                id: "123",
             })
         })
     })

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -399,11 +399,11 @@ describe("createEndpoint", () => {
     })
 
     describe("With method, route, and url", () => {
-        const endpont = createEndpoint("GET", "/users", (ctx) => {
+        const endpoint = createEndpoint("GET", "/users", (ctx) => {
             return Response.json({ method: ctx.method, route: ctx.route, url: ctx.url })
         })
 
-        const { GET } = createRouter([endpont])
+        const { GET } = createRouter([endpoint])
 
         test("Access method, route, and url from context", async ({ expect }) => {
             const get = await GET(new Request("https://example.com/users?id=123"))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "isolatedModules": true,
     "allowImportingTsExtensions": true,
     "paths": {
-      "@/*": ["./src/*"],
+      "@/*": ["./src/*"]
     },
     "baseUrl": "."
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import path from "node:path";
+import path from "node:path"
 import { defineConfig } from "vitest/config"
 
 export default defineConfig({


### PR DESCRIPTION
## Description

This pull request introduces multi-method support for endpoint definitions created with `createEndpoint`. Routes can now match multiple HTTP methods using a single handler, enabling more concise definitions and reducing duplicated logic when the same processing is required for different request methods.

This capability is particularly useful for endpoints that share validation, authentication, or response logic across methods such as GET and POST, while preserving a single, type-safe route definition.

```ts
import { createEndpoint } from "@aura-stack/router"

const auth = createEndpoint(["GET", "POST"], "/auth", (ctx) => {
  return Response.json({ method: ctx.method })
})
```
