### PR TITLE
feat(client): add cache, credentials, and mode options to `createClient`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Per-package version history is maintained inside each package’s own `CHANGELOG
 
 ### Added
 
+- Added `cache`, `credentials`, and `mode` RequestInit options in `createClient`. These options are passed to all requests made by the client. [#37](https://github.com/aura-stack-ts/router/pull/37)
+
 - Added support for multiple HTTP methods in endpoint definitions via `createEndpoint`. Multiple HTTP methods can now match the same route. [#36](https://github.com/aura-stack-ts/router/pull/36)
 
 - Added support for dynamic headers in `createClient`. Headers can now be returned as an object or a `Promise` resolving to an object. [#33](https://github.com/aura-stack-ts/router/pull/33)

--- a/docs/src/content/docs/create-client.mdx
+++ b/docs/src/content/docs/create-client.mdx
@@ -66,7 +66,7 @@ function createClient<InferRoute extends Router<any>>(options: ClientOptions): C
 | `headers`     | `Headers` \| `() => Headers \| Promise<Headers>` | Default headers to include in every request made by the client. |
 | `cache`       | `RequestCache`                                   | The cache mode to use for all requests.                         |
 | `credentials` | `RequestCredentials`                             | The credentials mode to use for all requests.                   |
-| `mode`        | `RequestMode`                                    | The mode to use for all requests                                |
+| `mode`        | `RequestMode`                                    | The mode to use for all requests.                               |
 
 #### `baseURL`
 

--- a/docs/src/content/docs/create-client.mdx
+++ b/docs/src/content/docs/create-client.mdx
@@ -59,11 +59,14 @@ import type { Router, InferEndpoints, Client, HTTPMethod, ClientOptions } from "
 function createClient<InferRoute extends Router<any>>(options: ClientOptions): Client<InferEndpoints<InferRouter>>
 ```
 
-| Parameter  | Type                                             | Description                                                     |
-| ---------- | ------------------------------------------------ | --------------------------------------------------------------- |
-| `baseURL`  | `string`                                         | The base URL where the router is hosted.                        |
-| `basePath` | `/${string}`                                     | An optional base path to prepend to all requests.               |
-| `headers`  | `Headers` \| `() => Headers \| Promise<Headers>` | Default headers to include in every request made by the client. |
+| Parameter     | Type                                             | Description                                                     |
+| ------------- | ------------------------------------------------ | --------------------------------------------------------------- |
+| `baseURL`     | `string`                                         | The base URL where the router is hosted.                        |
+| `basePath`    | `/${string}`                                     | An optional base path to prepend to all requests.               |
+| `headers`     | `Headers` \| `() => Headers \| Promise<Headers>` | Default headers to include in every request made by the client. |
+| `cache`       | `RequestCache`                                   | The cache mode to use for all requests.                         |
+| `credentials` | `RequestCredentials`                             | The credentials mode to use for all requests.                   |
+| `mode`        | `RequestMode`                                    | The mode to use for all requests                                |
 
 #### `baseURL`
 
@@ -110,6 +113,44 @@ export const client = createClient({
     "cache-control": "no-store",
     pragma: "no-cache",
   },
+})
+```
+
+#### `cache`
+
+Caching mode to use for all requests made by the client. For more details, see the [MDN documentation on RequestCache](https://developer.mozilla.org/en-US/docs/Web/API/Request/cache).
+
+```ts lineNumbers title="@/client"
+import { createClient } from "@aura-stack/router/client"
+
+export const client = createClient({
+  baseURL: "http://localhost:3000",
+  cache: "no-store",
+})
+```
+
+#### `credentials`
+
+Credentials mode to use for all requests made by the client. For more details, see the [MDN documentation on RequestCredentials](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials).
+
+```ts lineNumbers title="@/client"
+import { createClient } from "@aura-stack/router/client"
+
+export const client = createClient({
+  baseURL: "http://localhost:3000",
+  credentials: "include",
+})
+```
+
+#### `mode`
+
+Request mode to use for all requests made by the client. For more details, see the [MDN documentation on RequestMode](https://developer.mozilla.org/en-US/docs/Web/API/Request/mode).
+
+```ts lineNumbers title="@/client"
+import { createClient } from "@aura-stack/router/client"
+export const client = createClient({
+  baseURL: "http://localhost:3000",
+  mode: "cors",
 })
 ```
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,7 +17,7 @@ import type { Router, InferEndpoints, Client, HTTPMethod, ClientOptions } from "
  * client.get("/users")
  */
 export function createClient<InferRouter extends Router<any>>(options: ClientOptions): Client<InferEndpoints<InferRouter>> {
-    const { baseURL, headers: defaultHeaders } = options
+    const { baseURL, basePath, headers: defaultHeaders, ...clientOptions } = options
     return new Proxy(
         {},
         {
@@ -25,7 +25,8 @@ export function createClient<InferRouter extends Router<any>>(options: ClientOpt
                 const method = prop.toString().toUpperCase() as HTTPMethod
                 return async (path: string, ctx?: any) => {
                     const searchParams = new URLSearchParams(ctx?.searchParams)
-                    let resolvedPath = `${options.basePath ?? ""}${path}`
+
+                    let resolvedPath = `${basePath ?? ""}${path}`
                     for (const [key, value] of Object.entries(ctx?.params ?? {})) {
                         resolvedPath = resolvedPath.replace(`:${key}`, String(value))
                     }
@@ -38,7 +39,7 @@ export function createClient<InferRouter extends Router<any>>(options: ClientOpt
                     const { params: _p, searchParams: _s, ...requestInit } = ctx ?? {}
                     const headers = typeof defaultHeaders === "function" ? await defaultHeaders() : defaultHeaders
                     const response = await fetch(url.toString(), {
-                        ...options,
+                        ...clientOptions,
                         ...requestInit,
                         method,
                         headers: {

--- a/src/client.ts
+++ b/src/client.ts
@@ -38,6 +38,7 @@ export function createClient<InferRouter extends Router<any>>(options: ClientOpt
                     const { params: _p, searchParams: _s, ...requestInit } = ctx ?? {}
                     const headers = typeof defaultHeaders === "function" ? await defaultHeaders() : defaultHeaders
                     const response = await fetch(url.toString(), {
+                        ...options,
                         ...requestInit,
                         method,
                         headers: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -318,7 +318,7 @@ export type Router<Endpoints extends RouteEndpoint[]> = GetHttpHandlers<Endpoint
 
 export type InferEndpoints<T> = T extends Router<infer E> ? E : never
 
-export interface ClientOptions {
+export interface ClientOptions extends Pick<RequestInit, "cache" | "credentials" | "mode"> {
     /**
      * Base URL for the router client to make requests to the server.
      * This is useful when the server is hosted on a different origin.

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -165,4 +165,94 @@ describe("Client", () => {
             })
         )
     })
+
+    test("createClient with cache option", async () => {
+        const client = createClient<typeof router>({
+            baseURL: "http://api.example.com",
+            cache: "no-cache",
+        })
+        await client.get("/users")
+        expect(fetch).toHaveBeenCalledWith(
+            "http://api.example.com/users",
+            expect.objectContaining({
+                cache: "no-cache",
+            })
+        )
+    })
+
+    test("createClient with overridden cache option", async () => {
+        const client = createClient<typeof router>({
+            baseURL: "http://api.example.com",
+            cache: "no-cache",
+        })
+        await client.get("/users", {
+            cache: "reload",
+        })
+        expect(fetch).toHaveBeenCalledWith(
+            "http://api.example.com/users",
+            expect.objectContaining({
+                cache: "reload",
+            })
+        )
+    })
+
+    test("createClient with credentials option", async () => {
+        const client = createClient<typeof router>({
+            baseURL: "http://api.example.com",
+            credentials: "include",
+        })
+        await client.get("/users")
+        expect(fetch).toHaveBeenCalledWith(
+            "http://api.example.com/users",
+            expect.objectContaining({
+                credentials: "include",
+            })
+        )
+    })
+
+    test("createClient with overridden credentials option", async () => {
+        const client = createClient<typeof router>({
+            baseURL: "http://api.example.com",
+            credentials: "include",
+        })
+        await client.get("/users", {
+            credentials: "same-origin",
+        })
+        expect(fetch).toHaveBeenCalledWith(
+            "http://api.example.com/users",
+            expect.objectContaining({
+                credentials: "same-origin",
+            })
+        )
+    })
+
+    test("createClient with mode option", async () => {
+        const client = createClient<typeof router>({
+            baseURL: "http://api.example.com",
+            mode: "cors",
+        })
+        await client.get("/users")
+        expect(fetch).toHaveBeenCalledWith(
+            "http://api.example.com/users",
+            expect.objectContaining({
+                mode: "cors",
+            })
+        )
+    })
+
+    test("createClient with overridden mode option", async () => {
+        const client = createClient<typeof router>({
+            baseURL: "http://api.example.com",
+            mode: "cors",
+        })
+        await client.get("/users", {
+            mode: "no-cors",
+        })
+        expect(fetch).toHaveBeenCalledWith(
+            "http://api.example.com/users",
+            expect.objectContaining({
+                mode: "no-cors",
+            })
+        )
+    })
 })


### PR DESCRIPTION
## Description

This pull request adds support for `cache`, `credentials`, and `mode` request options in the `createClient` function. These options are applied globally to all requests performed by the client, providing a centralized way to configure fetch behavior across the application. Each option can still be overridden on a per-request basis when more granular control is required.

This enhancement improves flexibility when working with cross-origin requests, session-based authentication, and caching strategies, while maintaining consistent defaults at the client level.

```ts lineNumbers title="@/client"
import { createClient } from "@aura-stack/router/client"
export const client = createClient({
  baseURL: "http://localhost:3000",
  mode: "cors",
  credentials: "include",
  cache: "no-store"
})
```


### Resources
- [MDN documentation on RequestCache](https://developer.mozilla.org/en-US/docs/Web/API/Request/cache).
- [MDN documentation on RequestCredentials](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials).
- [MDN documentation on RequestMode](https://developer.mozilla.org/en-US/docs/Web/API/Request/mode).
