### PR TITLE
refactor(middleware)!: standardize middleware naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Per-package version history is maintained inside each package’s own `CHANGELOG
 
 ## [Unreleased]
 
+### BREAKING CHANGES
+
+- The `middlewares` option was renamed to `use` to align with standard conventions in backend libraries. Middleware behavior remains unchanged; only the name was updated for improved clarity. The option was renamed in `createRouter`, `createEndpoint`, and `createEndpointConfig`. [#38](https://github.com/aura-stack-ts/router/pull/38)
+
 ### Added
 
 - Added `cache`, `credentials`, and `mode` RequestInit options in `createClient`. These options are passed to all requests made by the client. [#37](https://github.com/aura-stack-ts/router/pull/37)

--- a/docs/src/content/docs/create-endpoint-config.mdx
+++ b/docs/src/content/docs/create-endpoint-config.mdx
@@ -67,7 +67,7 @@ const config = createEndpointConfig({
       state: z.string(),
     }),
   },
-  middlewares: [
+  use: [
     async (ctx) => {
       const { redirect_uri, code, state } = ctx.searchParams
       return ctx
@@ -90,7 +90,7 @@ const config = createEndpointConfig("/auth/signIn/:oauth/", {
       state: z.string(),
     }),
   },
-  middlewares: [
+  use: [
     async (ctx) => {
       const { oauth } = ctx.params
       const { redirect_uri, code, state } = ctx.searchParams

--- a/docs/src/content/docs/create-endpoint.mdx
+++ b/docs/src/content/docs/create-endpoint.mdx
@@ -563,7 +563,7 @@ type EndpointConfig<
   Schemas extends EndpointSchemas = EndpointSchemas,
 > = Prettify<{
   schemas?: Schemas
-  middlewares?: MiddlewareFunction<GetRouteParams<RouteParams>, { schemas: Schemas }>[]
+  use?: MiddlewareFunction<GetRouteParams<RouteParams>, { schemas: Schemas }>[]
 }>
 ```
 
@@ -618,7 +618,7 @@ export const signIn = createEndpoint("GET", "/auth/signIn/:oauth", async (ctx) =
 })
 ```
 
-### With `middlewares`
+### With `use`
 
 Middlewares run before the route handler and have access to the parsed and typed context (`ctx`).
 
@@ -633,7 +633,7 @@ const getProfile = createEndpoint(
     return Response.json({ userId })
   },
   {
-    middlewares: [
+    use: [
       // Authentication middleware
       async (ctx) => {
         const token = ctx.request.headers.get("authorization")
@@ -657,7 +657,7 @@ Several middlewares can be chained to compose complex request logic:
 
 ```ts lineNumbers
 const config = createEndpointConfig({
-  middlewares: [
+  use: [
     // Logging
     async (ctx) => {
       console.log(`Request to ${ctx.url}`)
@@ -708,7 +708,7 @@ const config = createEndpointConfig({
   schemas: {
     body: z.object({ name: z.string() }),
   },
-  middlewares: [
+  use: [
     /* ... */
   ],
 })
@@ -725,7 +725,7 @@ When the route pattern is passed as the first argument to `createEndpointConfig`
 import { createEndpointConfig, createEndpoint } from "@aura-stack/router"
 
 const config = createEndpointConfig("/users/:userId", {
-  middlewares: [
+  use: [
     async (ctx) => {
       const { userId } = ctx.params
       console.log(`Processing request for user ${userId}`)

--- a/docs/src/content/docs/create-router.mdx
+++ b/docs/src/content/docs/create-router.mdx
@@ -87,7 +87,7 @@ import { createRouter, type RouterConfig } from "@aura-stack/router"
 
 const routerConfig: RouterConfig = {
   basePath: "/api/",
-  middlewares: [],
+  use: [],
   onError: undefined,
   context: {},
 }
@@ -123,7 +123,7 @@ type createRouter = <const Endpoints extends RouteEndpoint[]>(
 import type { HTTPMethod, RoutePattern, EndpointConfig, RouteHandler } from "@aura-stack/router/types"
 
 interface RouteEndpoint<
-  Method extends HTTPMethod = HTTPMethod,
+  Method extends HTTPMethod | HTTPMethod[] = HTTPMethod | HTTPMethod[],
   Route extends RoutePattern = RoutePattern,
   Config extends EndpointConfig = EndpointConfig,
 > {
@@ -161,18 +161,18 @@ import type { RoutePattern, GlobalMiddleware, RouterError } from "@aura-stack/ro
 
 interface RouterConfig {
   basePath?: RoutePattern
-  middlewares?: GlobalMiddleware[]
+  use?: GlobalMiddleware[]
   onError?: (error: Error | RouterError, request: Request) => Response | Promise<Response>
   context?: GlobalMiddlewareContext
 }
 ```
 
-| Option        | Type                                                                               | Description                                                 |
-| ------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| `basePath`    | `string`                                                                           | Prefix applied to all routes (recommended: start with `/`). |
-| `middlewares` | `GlobalMiddleware[]`                                                               | Global middlewares executed before endpoint handlers.       |
-| `onError`     | `(error: Error \| RouterError, request: Request) => Response \| Promise<Response>` | Global error handler.                                       |
-| `context`     | `GlobalMiddlewareContext`                                                          | Global context for endpoints and middlewares.               |
+| Option     | Type                                                                               | Description                                                 |
+| ---------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| `basePath` | `string`                                                                           | Prefix applied to all routes (recommended: start with `/`). |
+| `use`      | `GlobalMiddleware[]`                                                               | Global middlewares executed before endpoint handlers.       |
+| `onError`  | `(error: Error \| RouterError, request: Request) => Response \| Promise<Response>` | Global error handler.                                       |
+| `context`  | `GlobalMiddlewareContext`                                                          | Global context for endpoints and middlewares.               |
 
 ##### `basePath` [#base-path]
 
@@ -215,9 +215,9 @@ const createUser = createEndpoint("POST", "/users", async (ctx) => {
 export const { GET, POST } = createRouter([getUsers, createUser], routerConfig)
 ```
 
-##### `middlewares` [#middlewares]
+##### `use` [#use]
 
-The `middlewares` configuration property defines global middleware functions that run for every matched request. Global middlewares execute after route matching but before endpoint middlewares and the route handler.
+The `use` configuration property defines global middleware functions that run for every matched request. Global middlewares execute after route matching but before endpoint middlewares and the route handler.
 
 <Callout>
   Global middlewares access the request via the `context` property. The context must be configured on the router to be accessible
@@ -257,7 +257,7 @@ const globalMiddleware: GlobalMiddleware = async (ctx) => {
 }
 
 export const router = createRouter([], {
-  middlewares: [globalMiddleware],
+  use: [globalMiddleware],
 })
 ```
 
@@ -280,7 +280,7 @@ const auditMiddleware: GlobalMiddleware = async (ctx) => {
 }
 
 export const router = createRouter([], {
-  middlewares: [auditMiddleware],
+  use: [auditMiddleware],
 })
 ```
 
@@ -300,7 +300,7 @@ const authorizationMiddleware: GlobalMiddleware = async (ctx) => {
 }
 
 export const router = createRouter([], {
-  middlewares: [authorizationMiddleware],
+  use: [authorizationMiddleware],
 })
 ```
 
@@ -316,7 +316,7 @@ Middlewares execute in a specific sequence:
 import { createRouter, createEndpoint, createEndpointConfig } from "@aura-stack/router"
 
 const endpointConfig = createEndpointConfig({
-  middlewares: [
+  use: [
     async (ctx) => {
       console.log("2. Endpoint middleware")
       return ctx
@@ -335,7 +335,7 @@ const endpoint = createEndpoint(
 )
 
 export const router = createRouter([endpoint], {
-  middlewares: [
+  use: [
     async (ctx) => {
       console.log("1. Global middleware")
       return ctx
@@ -574,7 +574,7 @@ const config: RouterConfig = {
 export const { GET, POST } = createRouter([getUsers, createUser], config)
 ```
 
-### With `middlewares`
+### With `use`
 
 ```ts lineNumbers
 import { createRouter, createEndpoint, type RouterConfig, type GlobalMiddleware } from "@aura-stack/router"
@@ -596,10 +596,10 @@ const auditMiddleware: GlobalMiddleware = async (ctx) => {
 }
 
 const config: RouterConfig = {
-  middlewares: [auditMiddleware],
+  use: [auditMiddleware],
 }
 
-export const { GET, POST } = createRouter([getUsers, createUser])
+export const { GET, POST } = createRouter([getUsers, createUser], config)
 ```
 
 ### With `onError`

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -114,14 +114,14 @@ export const router = createRouter([getUser, getUsers], {
 
 #### Global Middlewares
 
-The `middlewares` option registers logic that runs before every endpoint:
+The `use` option registers logic that runs before every endpoint:
 
 ```ts lineNumbers title="@/index.ts"
 import { createRouter } from "@aura-stack/router"
 import { getUser, getUsers } from "@/api/users.ts"
 
 export const router = createRouter([getUser, getUsers], {
-  middlewares: [
+  use: [
     (ctx) => {
       console.log(`[debug]: ${ctx.request.url}`)
       return ctx

--- a/docs/src/content/docs/middlewares.mdx
+++ b/docs/src/content/docs/middlewares.mdx
@@ -53,7 +53,7 @@ The following example demonstrates basic middleware usage without relying on the
 import { createEndpointConfig, createEndpoint } from "@aura-stack/router"
 
 const config = createEndpointConfig({
-  middlewares: [
+  use: [
     async (ctx) => {
       console.log(`Request to ${ctx.url}`)
       return ctx
@@ -79,7 +79,7 @@ const verifyToken = (token: string) => {
 }
 
 const authConfig = createEndpointConfig({
-  middlewares: [
+  use: [
     async (ctx) => {
       const token = ctx.request.headers.get("authorization")
 
@@ -122,7 +122,7 @@ Multiple middlewares execute in the order they are defined.
 
 ```ts lineNumbers
 const config = createEndpointConfig({
-  middlewares: [
+  use: [
     /*
      1. First middleware - logging
     */
@@ -165,7 +165,7 @@ When both global and endpoint middlewares are defined, they execute in the follo
 import { createEndpoint, createEndpointConfig, createRouter } from "@aura-stack/router"
 
 const endpointConfig = createEndpointConfig({
-  middlewares: [
+  use: [
     async (ctx) => {
       console.log("2. Endpoint middleware")
       return ctx
@@ -184,7 +184,7 @@ const endpoint = createEndpoint(
 )
 
 const router = createRouter([endpoint], {
-  middlewares: [
+  use: [
     async (ctx) => {
       console.log("1. Global middleware")
       return ctx

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -52,7 +52,7 @@ export const createEndpoint = <
  * @example
  * // Without route pattern
  * const config = createEndpointConfig({
- *   middlewares: [myMiddleware],
+ *   use: [myMiddleware],
  *   schemas: {
  *     searchParams: z.object({
  *       q: z.string().min(3),
@@ -66,7 +66,7 @@ export const createEndpoint = <
  *
  * // Overload with route pattern
  * const config = createEndpointConfig("/users/:userId", {
- *   middlewares: [myMiddleware],
+ *   use: [myMiddleware],
  * })
  *
  * const getUser = createEndpoint("GET", "/users/:userId", async (request, ctx) => {

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -6,11 +6,11 @@ import type { EndpointConfig, GlobalMiddlewareContext, MiddlewareFunction, Reque
  *
  * @param request - Original request made from the client
  * @param middlewares - Array of global middleware functions to be executed
- * @returns - The modified request after all middlewares have been executed
+ * @returns - The modified context after all middlewares have been executed
  */
-export const executeGlobalMiddlewares = async (context: GlobalMiddlewareContext, middlewares: RouterConfig["middlewares"]) => {
-    if (!middlewares) return context
-    for (const middleware of middlewares) {
+export const executeGlobalMiddlewares = async (context: GlobalMiddlewareContext, use: RouterConfig["use"]) => {
+    if (!use) return context
+    for (const middleware of use) {
         if (typeof middleware !== "function") {
             throw new RouterError("BAD_REQUEST", "Global middlewares must be functions")
         }
@@ -36,11 +36,11 @@ export const executeGlobalMiddlewares = async (context: GlobalMiddlewareContext,
  */
 export const executeMiddlewares = async <const RouteParams extends Record<string, string>, const Config extends EndpointConfig>(
     context: RequestContext<RouteParams, Config>,
-    middlewares: MiddlewareFunction<RouteParams, Config>[] = []
+    use: MiddlewareFunction<RouteParams, Config>[] = []
 ): Promise<RequestContext<RouteParams, Config>> => {
     try {
         let ctx = context
-        for (const middleware of middlewares) {
+        for (const middleware of use) {
             if (typeof middleware !== "function") {
                 throw new RouterError("BAD_REQUEST", "Middleware must be a function")
             }

--- a/src/router.ts
+++ b/src/router.ts
@@ -104,7 +104,7 @@ const handleRequest = async (method: HTTPMethod, request: Request, config: Route
             throw new RouterError("METHOD_NOT_ALLOWED", `The HTTP method '${request.method}' is not supported`)
         }
         const globalContext = { request, context: config.context ?? ({} as GlobalContext) }
-        const globalRequestContext = await executeGlobalMiddlewares(globalContext, config.middlewares)
+        const globalRequestContext = await executeGlobalMiddlewares(globalContext, config.use)
 
         if (globalRequestContext instanceof Response) return globalRequestContext
 
@@ -129,7 +129,7 @@ const handleRequest = async (method: HTTPMethod, request: Request, config: Route
             route: endpoint.route,
             context: config.context ?? ({} as GlobalContext),
         }
-        context = await executeMiddlewares(context, endpoint.config.middlewares)
+        context = await executeMiddlewares(context, endpoint.config.use)
         const response = await endpoint.handler(context)
         return response
     } catch (error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,7 +83,7 @@ export type EndpointConfig<
     Schemas extends EndpointSchemas = EndpointSchemas,
 > = Prettify<{
     schemas?: Schemas
-    middlewares?: MiddlewareFunction<GetRouteParams<RouteParams>, { schemas: Schemas }>[]
+    use?: MiddlewareFunction<GetRouteParams<RouteParams>, { schemas: Schemas }>[]
 }>
 
 /**
@@ -212,7 +212,7 @@ export interface RouterConfig extends GlobalCtx {
      * You can use this to modify the request or return a response early.
      *
      * @example
-     * middlewares: [
+     * use: [
      *   async (request) => {
      *     if(request.headers.get("Authorization")?.startsWith("Bearer ")) {
      *       return Response.json({ message: "Unauthorized" }, { status: 401 })
@@ -221,7 +221,7 @@ export interface RouterConfig extends GlobalCtx {
      *   }
      * ]
      */
-    middlewares?: GlobalMiddleware[]
+    use?: GlobalMiddleware[]
     /**
      * Error handler function that runs when an error is thrown in a router handler or middleware.
      * It can be used to customize the default error response provided by the router. If is an internal

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -8,7 +8,7 @@ describe("Client", () => {
     beforeEach(() => {
         vi.stubGlobal(
             "fetch",
-            vi.fn(async () => {
+            vi.fn(() => {
                 return new Response(JSON.stringify({ success: true }), { status: 200 })
             })
         )

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -232,7 +232,7 @@ describe("createEndpoint", () => {
                     return Response.json({ oauth })
                 },
                 {
-                    middlewares: [
+                    use: [
                         (ctx) => {
                             ctx.params = { oauth: "google" }
                             return ctx
@@ -255,7 +255,7 @@ describe("createEndpoint", () => {
                     return Response.json({ searchParams })
                 },
                 {
-                    middlewares: [
+                    use: [
                         (ctx) => {
                             ctx.searchParams.set("state", "123abc")
                             ctx.searchParams.set("code", "123")
@@ -281,7 +281,7 @@ describe("createEndpoint", () => {
                     return Response.json({ headers })
                 },
                 {
-                    middlewares: [
+                    use: [
                         (ctx) => {
                             ctx.headers.setHeader("Authorization", "Bearer token")
                             return ctx
@@ -313,7 +313,7 @@ describe("createEndpoint", () => {
                             password: z.string(),
                         }),
                     },
-                    middlewares: [
+                    use: [
                         (ctx) => {
                             ctx.body.username = "John Doe"
                             return ctx
@@ -349,7 +349,7 @@ describe("createEndpoint", () => {
                             redirect_uri: z.string(),
                         }),
                     },
-                    middlewares: [
+                    use: [
                         (ctx) => {
                             const searchParams = ctx.searchParams as any
                             searchParams.state = "123abc"
@@ -380,7 +380,7 @@ describe("createEndpoint", () => {
                 },
                 {
                     schemas: {},
-                    middlewares: [
+                    use: [
                         (ctx) => {
                             ctx.params.oauth = "google"
                             return ctx

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -16,7 +16,7 @@ describe("createRouter", () => {
             },
         })
         const sessionConfig = createEndpointConfig({
-            middlewares: [
+            use: [
                 (ctx) => {
                     ctx.headers.setCookie("session-token", "123abc-token")
                     return ctx
@@ -248,7 +248,7 @@ describe("createRouter", () => {
 
         describe("Add headers middleware", () => {
             const router = createRouter([session, signIn], {
-                middlewares: [
+                use: [
                     (ctx) => {
                         ctx.request.headers.set("x-powered-by", "@aura-stack")
                         return ctx
@@ -276,7 +276,7 @@ describe("createRouter", () => {
 
         describe("Block request middleware", () => {
             const router = createRouter([session], {
-                middlewares: [
+                use: [
                     (ctx) => {
                         if (!ctx.request.headers.get("authorization")) {
                             return new Response(JSON.stringify({ message: "Forbidden" }), {

--- a/test/type.test-d.ts
+++ b/test/type.test-d.ts
@@ -154,22 +154,22 @@ describe("MiddlewareFunction", () => {
         MiddlewareFunction<
             EmptyObject,
             {
-                middlewares: []
+                use: []
             }
         >
-    >().toEqualTypeOf<(ctx: RequestContext<EmptyObject, { middlewares: [] }>) => ReturnCtx<EmptyObject, { middlewares: [] }>>()
+    >().toEqualTypeOf<(ctx: RequestContext<EmptyObject, { use: [] }>) => ReturnCtx<EmptyObject, { use: [] }>>()
 
     expectTypeOf<
         MiddlewareFunction<
             EmptyObject,
             {
-                middlewares: [(ctx: RequestContext) => Promise<RequestContext<EmptyObject, { middlewares: [] }>>]
+                use: [(ctx: RequestContext) => Promise<RequestContext<EmptyObject, { use: [] }>>]
             }
         >
-    >().toEqualTypeOf<(ctx: RequestContext<EmptyObject, { middlewares: [] }>) => ReturnCtx<EmptyObject, { middlewares: [] }>>()
+    >().toEqualTypeOf<(ctx: RequestContext<EmptyObject, { use: [] }>) => ReturnCtx<EmptyObject, { use: [] }>>()
 
     expectTypeOf<MiddlewareFunction<GetRouteParams<"/auth/:oauth">>>().toEqualTypeOf<
-        (ctx: RequestContext<{ oauth: string }, { middlewares: [] }>) => ReturnCtx<{ oauth: string }, { middlewares: [] }>
+        (ctx: RequestContext<{ oauth: string }, { use: [] }>) => ReturnCtx<{ oauth: string }, { use: [] }>
     >()
 
     expectTypeOf<
@@ -177,7 +177,7 @@ describe("MiddlewareFunction", () => {
             GetRouteParams<"/auth/:oauth">,
             {
                 schemas: { searchParams: ZodObject<{ state: ZodString }> }
-                middlewares: []
+                use: []
             }
         >
     >().toEqualTypeOf<
@@ -353,7 +353,7 @@ describe("RequestContext", () => {
 describe("EndpointConfig", () => {
     expectTypeOf<EndpointConfig<"/">>().toEqualTypeOf<{
         schemas?: EndpointSchemas
-        middlewares?: MiddlewareFunction<
+        use?: MiddlewareFunction<
             GetRouteParams<"/">,
             {
                 schemas: EndpointSchemas
@@ -370,7 +370,7 @@ describe("EndpointConfig", () => {
         >
     >().toEqualTypeOf<{
         schemas?: { body: ZodObject<{ username: ZodString; password: ZodString }> }
-        middlewares?: MiddlewareFunction<
+        use?: MiddlewareFunction<
             GetRouteParams<"/">,
             {
                 schemas: {


### PR DESCRIPTION
## Description

This pull request standardizes middleware naming by replacing the `middlewares` property with `use`. The change aligns the API with common conventions in backend frameworks such as Express, Hono, and Fastify, where `use` is the standard keyword for registering middleware. The underlying middleware behavior and execution model remain unchanged.

> [!NOTE]
> **BREAKING CHANGE:** Middleware configuration has been renamed. Update all imports and usage from `middlewares` to `use`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Renamed the `middlewares` configuration option to `use` across all routing configuration paths (router configuration, endpoint configuration, and endpoint configs)

* **Documentation**
  * Updated all examples and documentation to reflect the new `use` property name throughout the API

<!-- end of auto-generated comment: release notes by coderabbit.ai -->