### PR TITLE
feat(client): allow custom fetch implementation in createClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Per-package version history is maintained inside each package’s own `CHANGELOG
 
 ### Added
 
+- Added a `fetch` configuration option in `createClient` to pass a custom fetch implementation. This option can be overridden by JavaScript library or framework integrations. [#40](https://github.com/aura-stack-ts/router/pull/40)
+
 - Added `cache`, `credentials`, and `mode` RequestInit options in `createClient`. These options are passed to all requests made by the client. [#37](https://github.com/aura-stack-ts/router/pull/37)
 
 - Added support for multiple HTTP methods in endpoint definitions via `createEndpoint`. Multiple HTTP methods can now match the same route. [#36](https://github.com/aura-stack-ts/router/pull/36)

--- a/src/client.ts
+++ b/src/client.ts
@@ -18,7 +18,7 @@ import type { Router, InferEndpoints, Client, HTTPMethod, ClientOptions } from "
  */
 export function createClient<InferRouter extends Router<any>>(options: ClientOptions): Client<InferEndpoints<InferRouter>> {
     const { baseURL, basePath, headers: defaultHeaders, fetch: customFetch, ...clientOptions } = options
-    const fetchFn = customFetch ?? globalThis.fetch.bind(globalThis)
+    const fetchFn = customFetch ?? ((input: RequestInfo | URL, init?: RequestInit) => globalThis.fetch(input, init))
 
     return new Proxy(
         {},
@@ -32,7 +32,6 @@ export function createClient<InferRouter extends Router<any>>(options: ClientOpt
                     for (const [key, value] of Object.entries(ctx?.params ?? {})) {
                         resolvedPath = resolvedPath.replace(`:${key}`, String(value))
                     }
-
                     const url = new URL(resolvedPath, baseURL)
                     if (searchParams.size > 0) {
                         url.search = searchParams.toString()

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,7 +17,9 @@ import type { Router, InferEndpoints, Client, HTTPMethod, ClientOptions } from "
  * client.get("/users")
  */
 export function createClient<InferRouter extends Router<any>>(options: ClientOptions): Client<InferEndpoints<InferRouter>> {
-    const { baseURL, basePath, headers: defaultHeaders, ...clientOptions } = options
+    const { baseURL, basePath, headers: defaultHeaders, fetch: customFetch, ...clientOptions } = options
+    const fetchFn = customFetch ?? globalThis.fetch.bind(globalThis)
+
     return new Proxy(
         {},
         {
@@ -38,7 +40,7 @@ export function createClient<InferRouter extends Router<any>>(options: ClientOpt
 
                     const { params: _p, searchParams: _s, ...requestInit } = ctx ?? {}
                     const headers = typeof defaultHeaders === "function" ? await defaultHeaders() : defaultHeaders
-                    const response = await fetch(url.toString(), {
+                    const response = await fetchFn(url.toString(), {
                         ...clientOptions,
                         ...requestInit,
                         method,

--- a/src/types.ts
+++ b/src/types.ts
@@ -318,6 +318,7 @@ export type Router<Endpoints extends RouteEndpoint[]> = GetHttpHandlers<Endpoint
 
 export type InferEndpoints<T> = T extends Router<infer E> ? E : never
 
+/** @experimental */
 export type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 
 export interface ClientOptions extends Pick<RequestInit, "cache" | "credentials" | "mode"> {
@@ -337,6 +338,7 @@ export interface ClientOptions extends Pick<RequestInit, "cache" | "credentials"
      */
     headers?: RequestHeaders | (() => RequestHeaders | Promise<RequestHeaders>)
     /**
+     * @experimental
      * Custom fetch function to be used by the client instead of the global fetch.
      */
     fetch?: FetchLike

--- a/src/types.ts
+++ b/src/types.ts
@@ -318,6 +318,8 @@ export type Router<Endpoints extends RouteEndpoint[]> = GetHttpHandlers<Endpoint
 
 export type InferEndpoints<T> = T extends Router<infer E> ? E : never
 
+export type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+
 export interface ClientOptions extends Pick<RequestInit, "cache" | "credentials" | "mode"> {
     /**
      * Base URL for the router client to make requests to the server.
@@ -334,6 +336,10 @@ export interface ClientOptions extends Pick<RequestInit, "cache" | "credentials"
      * Default headers to include in every request made by the client.
      */
     headers?: RequestHeaders | (() => RequestHeaders | Promise<RequestHeaders>)
+    /**
+     * Custom fetch function to be used by the client instead of the global fetch.
+     */
+    fetch?: FetchLike
 }
 
 export interface RequestHeaders extends Record<string, number | string | string[] | undefined> {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -8,8 +8,8 @@ describe("Client", () => {
     beforeEach(() => {
         vi.stubGlobal(
             "fetch",
-            vi.fn(() => {
-                return new Response(JSON.stringify({ success: true }), { status: 200 })
+            vi.fn((url, init) => {
+                return new Response(JSON.stringify({ success: true, url, init }), { status: 200 })
             })
         )
     })
@@ -254,5 +254,20 @@ describe("Client", () => {
                 mode: "no-cors",
             })
         )
+    })
+
+    test("createClient with custom fetch implementation", async () => {
+        const customFetch = vi.fn(() => {
+            return Promise.resolve(new Response(JSON.stringify({ success: true, custom: true }), { status: 200 }))
+        })
+
+        const client = createClient<typeof router>({
+            baseURL: "http://api.example.com",
+            fetch: customFetch,
+        })
+
+        const response = await client.get("/users")
+        const json = await response.json()
+        expect(json).toEqual({ success: true, custom: true })
     })
 })

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -8,8 +8,8 @@ describe("Client", () => {
     beforeEach(() => {
         vi.stubGlobal(
             "fetch",
-            vi.fn((url, init) => {
-                return new Response(JSON.stringify({ success: true, url, init }), { status: 200 })
+            vi.fn(() => {
+                return new Response(JSON.stringify({ success: true }), { status: 200 })
             })
         )
     })
@@ -269,5 +269,7 @@ describe("Client", () => {
         const response = await client.get("/users")
         const json = await response.json()
         expect(json).toEqual({ success: true, custom: true })
+        expect(customFetch).toHaveBeenCalledWith("http://api.example.com/users", expect.objectContaining({ method: "GET" }))
+        expect(fetch).not.toHaveBeenCalled()
     })
 })


### PR DESCRIPTION
## Description

This pull request introduces the `fetch` configuration option in the `createClient` function, allowing consumers to provide a custom fetch implementation that overrides the default behavior. This enhancement enables seamless integration with framework-specific fetch utilities and runtime-provided implementations, preserving any additional capabilities or abstractions layered on top of the standard Fetch API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can provide a custom fetch implementation when creating the client.
  * Client options now include an explicit baseURL option.

* **Tests**
  * Added a test validating the custom fetch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->