### PR TITLE
chore(release): bump package version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Per-package version history is maintained inside each package’s own `CHANGELOG
 
 ## [Unreleased]
 
+---
+
+## [0.6.0] - 2026-02-25
+
 ### BREAKING CHANGES
 
 - The `middlewares` option was renamed to `use` to align with standard conventions in backend libraries. Middleware behavior remains unchanged; only the name was updated for improved clarity. The option was renamed in `createRouter`, `createEndpoint`, and `createEndpointConfig`. [#38](https://github.com/aura-stack-ts/router/pull/38)

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/router",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "tasks": {
     "dev": "deno run --watch src/index.ts"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/router",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": false,
   "type": "module",
   "description": "A lightweight TypeScript library for building, managing, and validating API routes and endpoints in Node.js applications.",

--- a/src/error.ts
+++ b/src/error.ts
@@ -33,7 +33,7 @@ type StatusCode = keyof typeof statusCode
 /**
  * Reverse mapping of status codes to their corresponding status text.
  */
-export const statusText = Object.keys(statusCode).reduce(
+export const statusText: Record<StatusCode, StatusCode> = Object.keys(statusCode).reduce(
     (previous, status) => {
         return { ...previous, [status]: status }
     },


### PR DESCRIPTION
## Description

This pull request bumps the package version to **v0.6.0**. The new release introduces the Client API via the `createClient` function along with its associated methods, properties, and types. The function can be imported from either the `/client` entry point or the main index entry point. It provides full type-safety derived from the router definition through TypeScript’s `typeof` inference.

This version also advances the Aura Stack initiative to become an agnostic-runtime ecosystem. The package now supports Node.js, Bun, and Deno runtimes by relying on Web Standard APIs for cross-environment compatibility.

### BREAKING CHANGES
Additionally, middleware naming has been standardized from `middlewares` to `use`, aligning with common conventions in backend frameworks. This change was introduced in **#38** and represents a **breaking change**, requiring updates to existing middleware imports and usage.


### Key Changes

#### Client API
- #28  
- #33  
- #34  
- #36  
- #37  
- #38  
- #39  
- #40  


```ts
import { createEndpoint, createRouter, createClient } from "@aura-stack/router"

const getUsers = createEndpoint("GET", "/users", () => {
    return Response.json({ data: [
        { id: 1, name: "Alice" }
    ]})
})

const getUser = createEndpoint("GET", "/users/:id", (request) => {
    return Response.json({ data: { id: request.params.id } })
})

export const router = createRouter([getUsers, getUser])

const client = createClient<typeof router>({
    baseURL: "http://localhost:8000",
})

const response = await client.get("/users")
```

#### Cross Runtime
- #34  
- #35  


