### PR TITLE
feat(router): support `Valibot` schema validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     },
     "./types": "./dist/types.d.ts"
   },
+  "packageManager": "pnpm@10.15.0",
   "devDependencies": {
     "@types/bun": "^1.3.9",
     "@types/node": "24.6.2",
@@ -89,13 +90,22 @@
     "prettier": "^3.6.2",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.18",
+    "vitest": "^4.0.18"
+  },
+  "dependencies": {
+    "cookie": "^1.1.1"
+  },
+  "peerDependencies": {
     "zod": "^4.1.11",
     "valibot": "^1.4.0"
   },
-  "packageManager": "pnpm@10.15.0",
-  "dependencies": {
-    "cookie": "^1.1.1"
+  "peerDependenciesMeta": {
+    "zod": {
+      "optional": true
+    },
+    "valibot": {
+      "optional": true
+    }
   },
   "pnpm": {
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18",
-    "zod": "^4.1.11"
+    "zod": "^4.1.11",
+    "valibot": "^1.4.0"
   },
   "packageManager": "pnpm@10.15.0",
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      valibot:
+        specifier: ^1.4.0
+        version: 1.4.0(typescript@5.9.3)
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.30.1)
@@ -2383,6 +2386,14 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  valibot@1.4.0:
+    resolution: {integrity: sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -4997,6 +5008,10 @@ snapshots:
       '@types/react': 19.2.7
 
   util-deprecate@1.0.2: {}
+
+  valibot@1.4.0(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   vfile-message@4.0.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       cookie:
         specifier: ^1.1.1
         version: 1.1.1
+      valibot:
+        specifier: ^1.4.0
+        version: 1.4.0(typescript@5.9.3)
+      zod:
+        specifier: ^4.1.11
+        version: 4.1.12
     devDependencies:
       '@types/bun':
         specifier: ^1.3.9
@@ -36,15 +42,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
-      valibot:
-        specifier: ^1.4.0
-        version: 1.4.0(typescript@5.9.3)
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.30.1)
-      zod:
-        specifier: ^4.1.11
-        version: 4.1.12
 
   docs:
     dependencies:

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -1,5 +1,7 @@
 import { InvalidZodSchemaError, RouterError } from "@/error.ts"
 import type { RouteHandler, HTTPMethod, RoutePattern } from "@/types.ts"
+import { BaseSchema } from "valibot"
+import { ZodObject } from "zod"
 
 const supportedMethods = new Set<HTTPMethod>(["GET", "POST", "DELETE", "PUT", "PATCH", "OPTIONS", "HEAD", "TRACE", "CONNECT"])
 
@@ -83,4 +85,12 @@ export const isObject = (value: unknown): value is Record<string, unknown> => {
  */
 export const isInvalidZodSchemaError = (error: unknown): error is InvalidZodSchemaError => {
     return error instanceof InvalidZodSchemaError
+}
+
+export const isZodSchema = (value: unknown): value is ZodObject<any> => {
+    return typeof value === "object" && value !== null && "_def" in value
+}
+
+export const isValibotSchema = (value: unknown): value is BaseSchema<any, any, any> => {
+    return typeof value === "object" && value !== null && "~run" in value && typeof (value as any)["~run"] === "function"
 }

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -1,7 +1,7 @@
 import { InvalidZodSchemaError, RouterError } from "@/error.ts"
 import type { RouteHandler, HTTPMethod, RoutePattern } from "@/types.ts"
-import { BaseSchema } from "valibot"
-import { ZodObject } from "zod"
+import type { BaseSchema } from "valibot"
+import type { ZodObject } from "zod"
 
 const supportedMethods = new Set<HTTPMethod>(["GET", "POST", "DELETE", "PUT", "PATCH", "OPTIONS", "HEAD", "TRACE", "CONNECT"])
 
@@ -88,7 +88,7 @@ export const isInvalidZodSchemaError = (error: unknown): error is InvalidZodSche
 }
 
 export const isZodSchema = (value: unknown): value is ZodObject<any> => {
-    return typeof value === "object" && value !== null && "_def" in value
+    return typeof value === "object" && value !== null && "_zod" in value
 }
 
 export const isValibotSchema = (value: unknown): value is BaseSchema<any, any, any> => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,7 +1,8 @@
-import { isSupportedBodyMethod } from "./assert.ts"
-import { InvalidZodSchemaError, RouterError } from "./error.ts"
+import { isSupportedBodyMethod } from "@/assert.ts"
+import { InvalidZodSchemaError, RouterError } from "@/error.ts"
+import { createValidator } from "@/validator/registry.ts"
 import type { ZodError } from "zod"
-import type { EndpointConfig, ContextSearchParams, ContentType, JsonResponse } from "./types.ts"
+import type { EndpointConfig, ContextSearchParams, ContentType, JsonResponse } from "@/types.ts"
 
 /**
  * @experimental
@@ -43,7 +44,8 @@ export const formatZodError = (error: ZodError<Record<string, unknown>>) => {
  */
 export const getRouteParams = (params: Record<string, string>, config: EndpointConfig) => {
     if (config.schemas?.params) {
-        const parsed = config.schemas.params.safeParse(params)
+        const validator = createValidator(config.schemas.params)
+        const parsed = validator.validate(params)
         if (!parsed.success) {
             throw new InvalidZodSchemaError("UNPROCESSABLE_ENTITY", formatZodError(parsed.error))
         }
@@ -89,11 +91,12 @@ export const getSearchParams = <Config extends EndpointConfig>(
 ): ContextSearchParams<Config["schemas"]>["searchParams"] => {
     const route = new URL(url)
     if (config.schemas?.searchParams) {
-        const parsed = config.schemas.searchParams.safeParse(Object.fromEntries(route.searchParams.entries()))
+        const validator = createValidator(config.schemas.searchParams)
+        const parsed = validator.validate(Object.fromEntries(route.searchParams.entries()))
         if (!parsed.success) {
             throw new InvalidZodSchemaError("UNPROCESSABLE_ENTITY", formatZodError(parsed.error))
         }
-        return parsed.data
+        return parsed.data as ContextSearchParams<Config["schemas"]>["searchParams"]
     }
     return new URLSearchParams(route.searchParams.toString())
 }
@@ -119,7 +122,8 @@ export const getBody = async <Config extends EndpointConfig>(request: Request, c
     if (contentType.includes("application/json") || config.schemas?.body) {
         const json = await clone.json()
         if (config.schemas?.body) {
-            const parsed = config.schemas.body.safeParse(json)
+            const validator = createValidator(config.schemas.body)
+            const parsed = validator.validate(json)
             if (!parsed.success) {
                 throw new InvalidZodSchemaError("UNPROCESSABLE_ENTITY", formatZodError(parsed.error))
             }

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,6 +2,7 @@ import { isSupportedBodyMethod } from "@/assert.ts"
 import { InvalidZodSchemaError, RouterError } from "@/error.ts"
 import { createValidator } from "@/validator/registry.ts"
 import type { ZodError } from "zod"
+import type { BaseIssue } from "valibot"
 import type { EndpointConfig, ContextSearchParams, ContentType, JsonResponse } from "@/types.ts"
 
 /**
@@ -21,6 +22,14 @@ export const formatZodError = (error: ZodError<Record<string, unknown>>) => {
                 message: issue.message,
             },
         }
+    }, {})
+}
+
+export const formatValibotError = (issues: BaseIssue<unknown>[]) => {
+    if (!issues || issues.length === 0) return {}
+    return issues.reduce((prev, issue) => {
+        const key = issue.path?.map((p) => p.key).join(".") ?? ""
+        return { ...prev, [key]: { kind: issue.kind, message: issue.message } }
     }, {})
 }
 
@@ -47,7 +56,10 @@ export const getRouteParams = (params: Record<string, string>, config: EndpointC
         const validator = createValidator(config.schemas.params)
         const parsed = validator.validate(params)
         if (!parsed.success) {
-            throw new InvalidZodSchemaError("UNPROCESSABLE_ENTITY", formatZodError(parsed.error))
+            throw new InvalidZodSchemaError(
+                "UNPROCESSABLE_ENTITY",
+                Array.isArray(parsed.error) ? formatValibotError(parsed.error) : formatZodError(parsed.error)
+            )
         }
         return parsed.data
     }
@@ -94,7 +106,10 @@ export const getSearchParams = <Config extends EndpointConfig>(
         const validator = createValidator(config.schemas.searchParams)
         const parsed = validator.validate(Object.fromEntries(route.searchParams.entries()))
         if (!parsed.success) {
-            throw new InvalidZodSchemaError("UNPROCESSABLE_ENTITY", formatZodError(parsed.error))
+            throw new InvalidZodSchemaError(
+                "UNPROCESSABLE_ENTITY",
+                Array.isArray(parsed.error) ? formatValibotError(parsed.error) : formatZodError(parsed.error)
+            )
         }
         return parsed.data as ContextSearchParams<Config["schemas"]>["searchParams"]
     }
@@ -125,7 +140,10 @@ export const getBody = async <Config extends EndpointConfig>(request: Request, c
             const validator = createValidator(config.schemas.body)
             const parsed = validator.validate(json)
             if (!parsed.success) {
-                throw new InvalidZodSchemaError("UNPROCESSABLE_ENTITY", formatZodError(parsed.error))
+                throw new InvalidZodSchemaError(
+                    "UNPROCESSABLE_ENTITY",
+                    Array.isArray(parsed.error) ? formatValibotError(parsed.error) : formatZodError(parsed.error)
+                )
             }
             return parsed.data
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
-import type { ZodObject, z } from "zod"
+import type { ZodObject, ZodString, z } from "zod"
 import type { RouterError } from "./error.ts"
 import type { HeadersBuilder } from "./headers.ts"
+import type { ObjectSchema, InferOutput } from "valibot"
 
 /**
  * Route pattern must start with a slash and can contain parameters prefixed with a colon.
@@ -62,9 +63,9 @@ export type GetRouteParams<Route extends RoutePattern> = Route extends `/${infer
  * Available schemas validation for an endpoint. It can include body and searchParams schemas.
  */
 export interface EndpointSchemas {
-    body?: ZodObject<any>
-    searchParams?: ZodObject<any>
-    params?: ZodObject<any>
+    body?: ZodObject<any> | ObjectSchema<any, undefined>
+    searchParams?: ZodObject<any> | ObjectSchema<any, undefined>
+    params?: ZodObject<any> | ObjectSchema<any, undefined>
 }
 
 /**
@@ -90,35 +91,26 @@ export type EndpointConfig<
  */
 export type ContextSearchParams<Schemas extends EndpointConfig<any, any>["schemas"]> = Schemas extends { searchParams: ZodObject }
     ? { searchParams: z.infer<Schemas["searchParams"]> }
-    : { searchParams: URLSearchParams }
+    : Schemas extends { searchParams: ObjectSchema<any, undefined> }
+      ? { searchParams: InferOutput<Schemas["searchParams"]> }
+      : { searchParams: URLSearchParams }
 
 /**
  * Infer the type of body from the provided value in the `EndpointConfig`.
  */
 export type ContextBody<Schemas extends EndpointConfig<any, any>["schemas"]> = Schemas extends { body: ZodObject }
     ? { body: z.infer<Schemas["body"]> }
-    : { body: undefined }
+    : Schemas extends { body: ObjectSchema<any, undefined> }
+      ? { body: InferOutput<Schemas["body"]> }
+      : { body: undefined }
 
-type IsAny<T> = 0 extends 1 & T ? true : false
-
-type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false
-
-export type ContextParams<Schemas, Default extends Record<string, string> = Record<string, string>> = [Schemas] extends [
-    EndpointConfig<infer _, infer Schemas>,
-]
-    ? [IsAny<Schemas>] extends [true]
-        ? { params: Default }
-        : [Equals<Schemas, EndpointSchemas>] extends [true]
-          ? { params: Default }
-          : [{ params: ZodObject<any> }] extends [Schemas]
-            ? { params: z.infer<Schemas["params"]> }
-            : { params: Default }
-    : { params: Default }
-
-export type unstable__ContextParams<
-    Schemas extends EndpointConfig<any, any>["schemas"],
-    Default extends Record<string, string> = Record<string, string>,
-> = Schemas extends { params: ZodObject<any> } ? z.infer<Schemas["params"]> : Default
+export type ContextParams<Schemas extends EndpointSchemas, Default extends Record<string, string> = Record<string, string>> = [
+    Schemas,
+] extends [{ params: ZodObject<any> }]
+    ? { params: z.infer<Schemas["params"]> }
+    : [Schemas] extends [{ params: ObjectSchema<any, undefined> }]
+      ? { params: InferOutput<Schemas["params"]> }
+      : { params: Default }
 
 declare const jsonResponseBrand: unique symbol
 
@@ -138,7 +130,7 @@ export type RequestContext<
     Config extends EndpointConfig = EndpointConfig,
     Method extends HTTPMethod | HTTPMethod[] = HTTPMethod | HTTPMethod[],
 > = {
-    params: ContextParams<Config["schemas"], GetRouteParams<Route>>["params"]
+    params: ContextParams<NonNullable<Config["schemas"]>, GetRouteParams<Route>>["params"]
     headers: HeadersBuilder
     body: ContextBody<NonNullable<Config["schemas"]>>["body"]
     searchParams: ContextSearchParams<NonNullable<Config["schemas"]>>["searchParams"]

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
-import type { ZodObject, ZodString, z } from "zod"
+import type { ZodObject, z } from "zod"
 import type { RouterError } from "./error.ts"
 import type { HeadersBuilder } from "./headers.ts"
-import type { ObjectSchema, InferOutput } from "valibot"
+import type { ObjectSchema, InferOutput, StringSchema, InferInput } from "valibot"
 
 /**
  * Route pattern must start with a slash and can contain parameters prefixed with a colon.
@@ -278,10 +278,10 @@ export interface RouterConfig extends GlobalCtx {
     onError?: (error: Error | RouterError, request: Request) => Response | Promise<Response>
 }
 
-export type InferZod<T> = T extends z.ZodTypeAny ? z.infer<T> : T
+export type InferSchema<T> = T extends z.ZodTypeAny ? z.infer<T> : T extends ObjectSchema<any, undefined> ? InferOutput<T> : T
 
-export type ToInferZod<T> = {
-    [K in keyof T]: InferZod<T[K]>
+export type ToInferSchema<T> = {
+    [K in keyof T]: InferSchema<T[K]>
 }
 
 export type RemoveUndefined<T> = {
@@ -289,7 +289,20 @@ export type RemoveUndefined<T> = {
 }
 
 type HasSchemas<C> =
-    C extends EndpointConfig<any, infer Schemas> ? (Schemas[keyof Schemas] extends ZodObject<any> ? true : false) : false
+    C extends EndpointConfig<any, infer Schemas>
+        ? Schemas[keyof Schemas] extends ZodObject<any> | ObjectSchema<any, undefined>
+            ? true
+            : false
+        : false
+
+type InferContent<Config extends EndpointConfig<any, any>> =
+    Config extends EndpointConfig<any, infer Schemas>
+        ? Schemas[keyof Schemas] extends ZodObject<any>
+            ? RemoveUndefined<ToInferSchema<Schemas>>
+            : Schemas[keyof Schemas] extends ObjectSchema<any, undefined>
+              ? RemoveUndefined<ToInferSchema<Schemas>>
+              : unknown
+        : unknown
 
 export type Client<Endpoints extends readonly RouteEndpoint<any, any, any, any>[]> = Endpoints extends unknown[]
     ? Endpoints extends [infer First, ...infer Rest]
@@ -300,7 +313,7 @@ export type Client<Endpoints extends readonly RouteEndpoint<any, any, any, any>[
                           ? (path: Route, ctx?: RequestInit) => ReturnType<Handler> | Promise<ReturnType<Handler>>
                           : (
                                 path: Route,
-                                ctx: Omit<RequestInit, "body"> & RemoveUndefined<ToInferZod<NonNullable<Config["schemas"]>>>
+                                ctx: Omit<RequestInit, "body"> & InferContent<Config>
                             ) => ReturnType<Handler> | Promise<ReturnType<Handler>>
                   } & Client<Rest extends readonly RouteEndpoint<any, any, any, any>[] ? Rest : []>
               >

--- a/src/validator/registry.ts
+++ b/src/validator/registry.ts
@@ -1,0 +1,35 @@
+import { safeParse } from "valibot"
+import { isValibotSchema, isZodSchema } from "@/assert.ts"
+
+export type ValidationResult<T> = { success: true; data: T; error: null } | { success: false; data: null; error: any }
+
+export interface SchemaAdapter<T> {
+    validate: (data: unknown) => ValidationResult<T>
+}
+
+/**
+ * Universal wrapper for Zod, Valibot, ArkType, etc.
+ */
+export const createValidator = <T>(schema: any): SchemaAdapter<T> => {
+    return {
+        validate: (data: unknown): ValidationResult<T> => {
+            try {
+                if (isZodSchema(schema)) {
+                    const result = schema.safeParse(data)
+                    return result.success
+                        ? { success: true, data: result.data as T, error: null }
+                        : { success: false, data: null, error: result.error }
+                }
+                if (isValibotSchema(schema)) {
+                    const result = safeParse(schema, data)
+                    return result.issues
+                        ? { success: false, data: null, error: result.issues }
+                        : { success: true, data: result.output, error: null }
+                }
+                throw new Error("Unsupported schema type")
+            } catch (e) {
+                return { success: false, data: null, error: e }
+            }
+        },
+    }
+}

--- a/src/validator/registry.ts
+++ b/src/validator/registry.ts
@@ -11,6 +11,9 @@ export interface SchemaAdapter<T> {
  * Universal wrapper for Zod, Valibot, ArkType, etc.
  */
 export const createValidator = <T>(schema: any): SchemaAdapter<T> => {
+    if (!isZodSchema(schema) && !isValibotSchema(schema)) {
+        throw new Error("Unsupported schema type")
+    }
     return {
         validate: (data: unknown): ValidationResult<T> => {
             try {
@@ -22,11 +25,11 @@ export const createValidator = <T>(schema: any): SchemaAdapter<T> => {
                 }
                 if (isValibotSchema(schema)) {
                     const result = safeParse(schema, data)
-                    return result.issues
-                        ? { success: false, data: null, error: result.issues }
-                        : { success: true, data: result.output, error: null }
+                    return result.success
+                        ? { success: true, data: result.output, error: null }
+                        : { success: false, data: null, error: result.issues }
                 }
-                throw new Error("Unsupported schema type")
+                return { success: false, data: null, error: new Error("Unsupported schema type") }
             } catch (e) {
                 return { success: false, data: null, error: e }
             }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, vi, beforeEach, expectTypeOf } from "vitest"
-import { z } from "zod"
+import { never, z } from "zod"
+import * as valibot from "valibot"
 import { createRouter } from "@/router.ts"
 import { createEndpoint } from "@/endpoint.ts"
 import { createClient } from "@/client.ts"
@@ -282,7 +283,7 @@ describe("Client", () => {
     })
 })
 
-test("Client type inference", async () => {
+test("Client type inference with Zod schemas", async () => {
     const getItem = createEndpoint(
         "GET",
         "/items/:itemId",
@@ -318,6 +319,72 @@ test("Client type inference", async () => {
 
     const client = createClient<typeof router>({
         baseURL: "http://api.example.com",
+    })
+
+    client.get("/items/:itemId", {
+        params: { itemId: "123" },
+    })
+
+    const item = await client.get("/items/:itemId", {
+        params: { itemId: "123" },
+    })
+    expectTypeOf<typeof item>().toEqualTypeOf<JsonResponse<{ method: "GET" }>>()
+
+    const newItem = await client.post("/items", {
+        body: JSON.stringify({ name: "New Item" }),
+        headers: { "Content-Type": "application/json" },
+    })
+    expectTypeOf<typeof newItem>().toEqualTypeOf<JsonResponse<{ method: "POST" }>>()
+
+    const deletedItem = await client.delete("/items/:itemId", {
+        params: { itemId: "123" },
+        searchParams: { force: "true" },
+    })
+    expectTypeOf<typeof deletedItem>().toEqualTypeOf<JsonResponse<{ method: "DELETE" }>>()
+})
+
+test("Client type inference with Valibot schemas", async () => {
+    const getItem = createEndpoint(
+        "GET",
+        "/items/:itemId",
+        (ctx) => {
+            return ctx.json({ method: ctx.method })
+        },
+        {
+            schemas: {
+                params: valibot.object({ itemId: valibot.string() }),
+            },
+        }
+    )
+
+    const createItem = createEndpoint("POST", "/items", (ctx) => {
+        return ctx.json({ method: ctx.method })
+    })
+
+    const deleteItem = createEndpoint(
+        "DELETE",
+        "/items/:itemId",
+        (ctx) => {
+            return ctx.json({ method: ctx.method })
+        },
+        {
+            schemas: {
+                params: valibot.object({ itemId: valibot.string() }),
+                searchParams: valibot.object({ force: valibot.string() }),
+            },
+        }
+    )
+
+    const router = createRouter([getItem, createItem, deleteItem])
+
+    const client = createClient<typeof router>({
+        baseURL: "http://api.example.com",
+    })
+
+    client.get("/items/:itemId", {
+        params: {
+            itemId: "123",
+        },
     })
 
     client.get("/items/:itemId", {

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -1,4 +1,5 @@
 import z from "zod"
+import * as valibot from "valibot"
 import { describe, test } from "vitest"
 import { createRouter } from "@/router.ts"
 import { createEndpoint, createEndpointConfig } from "@/endpoint.ts"
@@ -75,7 +76,7 @@ describe("createEndpoint", () => {
     })
 
     describe("With schemas", () => {
-        describe("With body schema", () => {
+        describe("Zod body schema", () => {
             const endpoint = createEndpoint(
                 "POST",
                 "/auth/credentials",
@@ -121,7 +122,53 @@ describe("createEndpoint", () => {
             })
         })
 
-        describe("With searchParams schema", () => {
+        describe("Valibot body schema", () => {
+            const endpoint = createEndpoint(
+                "POST",
+                "/auth/credentials",
+                (ctx) => {
+                    return Response.json({ body: ctx.body })
+                },
+                {
+                    schemas: {
+                        body: valibot.object({
+                            username: valibot.string(),
+                            password: valibot.string(),
+                        }),
+                    },
+                }
+            )
+            const { POST } = createRouter([endpoint])
+
+            test("With valid body", async ({ expect }) => {
+                const post = await POST(
+                    new Request("https://example.com/auth/credentials", {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({ username: "John", password: "secret" }),
+                    })
+                )
+                expect(post.ok).toBe(true)
+                expect(await post.json()).toEqual({
+                    body: { username: "John", password: "secret" },
+                })
+            })
+
+            test("With invalid body", async ({ expect }) => {
+                const post = await POST(
+                    new Request("https://example.com/auth/credentials", {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({ username: "John" }),
+                    })
+                )
+                expect(post.status).toBe(422)
+                expect(await post.json()).toMatchObject({ error: "validation_error", details: {} })
+                expect(post.statusText).toBe("UNPROCESSABLE_ENTITY")
+            })
+        })
+
+        describe("Zod searchParams schema", () => {
             const endpoint = createEndpoint(
                 "GET",
                 "/auth/:oauth",
@@ -156,7 +203,42 @@ describe("createEndpoint", () => {
             })
         })
 
-        describe("With params schema", () => {
+        describe("Valibot searchParams schema", () => {
+            const endpoint = createEndpoint(
+                "GET",
+                "/auth/:oauth",
+                (ctx) => {
+                    return Response.json({ searchParams: ctx.searchParams })
+                },
+                {
+                    schemas: {
+                        searchParams: valibot.object({
+                            state: valibot.string(),
+                            code: valibot.string(),
+                        }),
+                    },
+                }
+            )
+
+            const { GET } = createRouter([endpoint])
+
+            test("With valid searchParams", async ({ expect }) => {
+                const get = await GET(new Request("https://example.com/auth/google?state=123abc&code=123"))
+                expect(get.ok).toBe(true)
+                expect(await get.json()).toEqual({
+                    searchParams: { state: "123abc", code: "123" },
+                })
+            })
+
+            test("With invalid searchParams", async ({ expect }) => {
+                const get = await GET(new Request("https://example.com/auth/google?state=123abc", { method: "GET" }))
+                expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
+                expect(get.status).toBe(422)
+                expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
+            })
+        })
+
+        describe("Zod params schema", () => {
             const config = createEndpointConfig("/signIn/:oauth", {
                 schemas: {
                     params: z.object({
@@ -169,6 +251,71 @@ describe("createEndpoint", () => {
                 schemas: {
                     params: z.object({
                         typeId: z.enum(["token", "code"]),
+                    }),
+                },
+            })
+
+            const endpoint = createEndpoint(
+                "GET",
+                "/signIn/:oauth",
+                (ctx) => {
+                    const oauth = ctx.params.oauth
+                    return Response.json({ oauth })
+                },
+                config
+            )
+
+            const inferEndpoint = createEndpoint(
+                "GET",
+                "/type/:typeId",
+                (ctx) => {
+                    return Response.json({ typeId: ctx.params.typeId })
+                },
+                inferConfig
+            )
+
+            const { GET } = createRouter([endpoint, inferEndpoint])
+
+            test("With valid params", async ({ expect }) => {
+                const get = await GET(new Request("https://example.com/signIn/google"))
+                expect(get.ok).toBe(true)
+                expect(await get.json()).toEqual({ oauth: "google" })
+            })
+
+            test("With invalid params", async ({ expect }) => {
+                const get = await GET(new Request("https://example.com/signIn/facebook"))
+                expect(get.status).toBe(422)
+                expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
+                expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
+            })
+
+            test("With inferred params", async ({ expect }) => {
+                const get = await GET(new Request("https://example.com/type/token"))
+                expect(get.ok).toBe(true)
+                expect(await get.json()).toEqual({ typeId: "token" })
+            })
+
+            test("With invalid inferred params", async ({ expect }) => {
+                const get = await GET(new Request("https://example.com/type/invalid"))
+                expect(get.status).toBe(422)
+                expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
+                expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
+            })
+        })
+
+        describe("Valibot params schema", () => {
+            const config = createEndpointConfig("/signIn/:oauth", {
+                schemas: {
+                    params: valibot.object({
+                        oauth: valibot.enum({ google: "google", github: "github" }),
+                    }),
+                },
+            })
+
+            const inferConfig = createEndpointConfig("/type/:typeId", {
+                schemas: {
+                    params: valibot.object({
+                        typeId: valibot.enum({ token: "token", code: "code" }),
                     }),
                 },
             })

--- a/test/type.test-d.ts
+++ b/test/type.test-d.ts
@@ -74,18 +74,6 @@ describe("RequestContext", () => {
             json: <T>(data: T, init?: ResponseInit) => JsonResponse<T>
         } & T
     >
-
-    type Nose = RequestContext<
-        any,
-        {
-            schemas: {
-                body: ZodObject<{
-                    username: ZodString
-                }>
-            }
-        }
-    >
-
     expectTypeOf<RequestContext>().toEqualTypeOf<
         Context<{
             params: {}

--- a/test/type.test-d.ts
+++ b/test/type.test-d.ts
@@ -19,8 +19,10 @@ import type {
     JsonResponse,
     InferEndpoints,
     RouteHandlerReturn,
+    ContextParams,
 } from "../src/types.ts"
-import { type ZodObject, type ZodString } from "zod"
+import { ZodEnum, type ZodObject, type ZodString } from "zod"
+import { EnumSchema, ObjectSchema, StringSchema } from "valibot"
 
 type RoutePath = "/auth/:oauth"
 type EmptyObject = Record<PropertyKey, never>
@@ -71,6 +73,17 @@ describe("RequestContext", () => {
             context: GlobalContext
             json: <T>(data: T, init?: ResponseInit) => JsonResponse<T>
         } & T
+    >
+
+    type Nose = RequestContext<
+        any,
+        {
+            schemas: {
+                body: ZodObject<{
+                    username: ZodString
+                }>
+            }
+        }
     >
 
     expectTypeOf<RequestContext>().toEqualTypeOf<
@@ -347,6 +360,31 @@ describe("ContextSearchParams", () => {
             }>
         >().toEqualTypeOf<{ searchParams: { code: string; state: string } }>()
     })
+
+    describe("ObjectSchema instance", () => {
+        expectTypeOf<
+            ContextSearchParams<{
+                searchParams: ObjectSchema<
+                    {
+                        code: StringSchema<undefined>
+                    },
+                    undefined
+                >
+            }>
+        >().toEqualTypeOf<{ searchParams: { code: string } }>()
+
+        expectTypeOf<
+            ContextSearchParams<{
+                searchParams: ObjectSchema<
+                    {
+                        code: StringSchema<undefined>
+                        state: StringSchema<undefined>
+                    },
+                    undefined
+                >
+            }>
+        >().toEqualTypeOf<{ searchParams: { code: string; state: string } }>()
+    })
 })
 
 describe("ContextBody", () => {
@@ -372,6 +410,117 @@ describe("ContextBody", () => {
                 }>
             }>
         >().toEqualTypeOf<{ body: { oauth: string } }>()
+    })
+
+    describe("ObjectSchema instance", () => {
+        expectTypeOf<
+            ContextBody<{
+                body: ObjectSchema<
+                    {
+                        username: StringSchema<undefined>
+                        password: StringSchema<undefined>
+                    },
+                    undefined
+                >
+            }>
+        >().toEqualTypeOf<{ body: { username: string; password: string } }>()
+
+        expectTypeOf<
+            ContextBody<{
+                body: ObjectSchema<
+                    {
+                        oauth: StringSchema<undefined>
+                    },
+                    undefined
+                >
+            }>
+        >().toEqualTypeOf<{ body: { oauth: string } }>()
+    })
+})
+
+describe("ContextParams", () => {
+    describe("No route params", () => {
+        expectTypeOf<ContextParams<{}, {}>>().toEqualTypeOf<{ params: {} }>()
+        expectTypeOf<ContextParams<{}>>().toEqualTypeOf<{ params: Record<string, string> }>()
+    })
+
+    describe("With route params", () => {
+        expectTypeOf<ContextParams<{}, GetRouteParams<RoutePath>>>().toEqualTypeOf<{ params: { oauth: string } }>()
+        expectTypeOf<ContextParams<EndpointSchemas, GetRouteParams<RoutePath>>>().toEqualTypeOf<{
+            params: { oauth: string }
+        }>()
+    })
+
+    describe("With route params and schemas", () => {
+        expectTypeOf<
+            ContextParams<
+                {
+                    params: ZodObject<{
+                        oauth: ZodString
+                    }>
+                },
+                GetRouteParams<RoutePath>
+            >
+        >().toEqualTypeOf<{ params: { oauth: string } }>()
+
+        expectTypeOf<
+            ContextParams<{
+                params: ZodObject<{
+                    role: ZodEnum<{ admin: "admin"; user: "user"; guest: "guest" }>
+                }>
+            }>
+        >().toEqualTypeOf<{ params: { role: "admin" | "user" | "guest" } }>()
+
+        expectTypeOf<
+            ContextParams<{
+                params: ObjectSchema<
+                    {
+                        oauth: EnumSchema<{ admin: "admin"; user: "user"; guest: "guest" }, undefined>
+                    },
+                    undefined
+                >
+            }>
+        >().toEqualTypeOf<{ params: { oauth: "admin" | "user" | "guest" } }>()
+
+        expectTypeOf<
+            ContextParams<
+                {
+                    params: ZodObject<{
+                        userId: ZodString
+                        itemId: ZodString
+                    }>
+                },
+                GetRouteParams<RoutePath>
+            >
+        >().toEqualTypeOf<{ params: { userId: string; itemId: string } }>()
+
+        expectTypeOf<
+            ContextParams<
+                {
+                    params: ObjectSchema<
+                        {
+                            oauth: StringSchema<undefined>
+                        },
+                        undefined
+                    >
+                },
+                GetRouteParams<RoutePath>
+            >
+        >().toEqualTypeOf<{ params: { oauth: string } }>()
+        expectTypeOf<
+            ContextParams<
+                {
+                    params: ObjectSchema<
+                        {
+                            userId: StringSchema<undefined>
+                            itemId: StringSchema<undefined>
+                        },
+                        undefined
+                    >
+                },
+                GetRouteParams<RoutePath>
+            >
+        >().toEqualTypeOf<{ params: { userId: string; itemId: string } }>()
     })
 })
 


### PR DESCRIPTION
## Description

Adds support for Valibot schema validation alongside the existing Zod integration for route validation.

Validation schemas can now be defined using Valibot for:
- route parameters
- search parameters
- request body content

This change was introduced as part of the work in aura-stack-ts/auth#160 and expands compatibility with additional schema validation libraries such as Valibot, ArkType, and future adapters.

### Key Changes
- Add Valibot schema validation support
- Enable Valibot-based inference for endpoint schemas
- Extend validation support beyond Zod


### Usage
```ts
import * as valibot from "valibot"

import {
  createEndpoint,
  createRouter,
  createClient,
} from "@aura-stack/router"

const credentials = createEndpoint(
  "POST",
  "/auth/credentials",
  (ctx) => {
    return ctx.json({ success: true })
  },
  {
    schemas: {
      body: valibot.object({
        username: valibot.string(),
        password: valibot.string(),
      }),
    },
  }
)

const router = createRouter([credentials])

const client = createClient<typeof router>({
  baseURL: "http://api.example.com",
})

await client.post("/auth/credentials", {
  body: {
    username: "johndoe",
    password: "1234567890",
  },
})
```
