### PR TITLE
feat(router): support `Arktype` schema validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,13 +97,17 @@
   },
   "peerDependencies": {
     "zod": "^4.1.11",
-    "valibot": "^1.4.0"
+    "valibot": "^1.4.0",
+    "arktype": "^2.0.0"
   },
   "peerDependenciesMeta": {
     "zod": {
       "optional": true
     },
     "valibot": {
+      "optional": true
+    },
+    "arktype": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
 
   .:
     dependencies:
+      arktype:
+        specifier: ^2.0.0
+        version: 2.2.0
       cookie:
         specifier: ^1.1.1
         version: 1.1.1
@@ -109,6 +112,12 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@ark/schema@0.56.0':
+    resolution: {integrity: sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA==}
+
+  '@ark/util@0.56.0':
+    resolution: {integrity: sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA==}
 
   '@emnapi/runtime@1.5.0':
     resolution: {integrity: sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==}
@@ -1242,6 +1251,12 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  arkregex@0.0.5:
+    resolution: {integrity: sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw==}
+
+  arktype@2.2.0:
+    resolution: {integrity: sha512-t54MZ7ti5BhOEvzEkgKnWvqj+UbDfWig+DHr5I34xatymPusKLS0lQpNJd8M6DzmIto2QGszHfNKoFIT8tMCZQ==}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -2510,6 +2525,12 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@ark/schema@0.56.0':
+    dependencies:
+      '@ark/util': 0.56.0
+
+  '@ark/util@0.56.0': {}
+
   '@emnapi/runtime@1.5.0':
     dependencies:
       tslib: 2.8.1
@@ -3491,6 +3512,16 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  arkregex@0.0.5:
+    dependencies:
+      '@ark/util': 0.56.0
+
+  arktype@2.2.0:
+    dependencies:
+      '@ark/schema': 0.56.0
+      '@ark/util': 0.56.0
+      arkregex: 0.0.5
 
   astring@1.9.0: {}
 

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -1,7 +1,8 @@
 import { InvalidZodSchemaError, RouterError } from "@/error.ts"
 import type { RouteHandler, HTTPMethod, RoutePattern } from "@/types.ts"
-import type { BaseSchema } from "valibot"
+import type { Type } from "arktype"
 import type { ZodObject } from "zod"
+import type { BaseSchema } from "valibot"
 
 const supportedMethods = new Set<HTTPMethod>(["GET", "POST", "DELETE", "PUT", "PATCH", "OPTIONS", "HEAD", "TRACE", "CONNECT"])
 
@@ -93,4 +94,8 @@ export const isZodSchema = (value: unknown): value is ZodObject<any> => {
 
 export const isValibotSchema = (value: unknown): value is BaseSchema<any, any, any> => {
     return typeof value === "object" && value !== null && "~run" in value && typeof (value as any)["~run"] === "function"
+}
+
+export const isArkType = (value: unknown): value is Type<{}, {}> => {
+    return typeof value === "function" && value !== null && "allows" in value && "assert" in value
 }

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -97,5 +97,5 @@ export const isValibotSchema = (value: unknown): value is BaseSchema<any, any, a
 }
 
 export const isArkType = (value: unknown): value is Type<{}, {}> => {
-    return typeof value === "function" && value !== null && "allows" in value && "assert" in value
+    return typeof value === "function" && "allows" in value && "assert" in value
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,8 @@
+import type { Type } from "arktype"
 import type { ZodObject, z } from "zod"
 import type { RouterError } from "./error.ts"
 import type { HeadersBuilder } from "./headers.ts"
 import type { ObjectSchema, InferOutput, StringSchema, InferInput } from "valibot"
-import { Type } from "arktype"
 
 /**
  * Route pattern must start with a slash and can contain parameters prefixed with a colon.

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,10 +84,8 @@ export type EndpointConfig<
     Schemas extends EndpointSchemas = EndpointSchemas,
 > = Prettify<{
     schemas?: Schemas
-    use?: MiddlewareFunction<
-        Route,
-        EndpointConfig<Route, { body: Schemas["body"]; params: Schemas["params"]; searchParams: Schemas["searchParams"] }>
-    >[]
+    //use?: MiddlewareFunction<Route, Schemas>[]
+    use?: MiddlewareFunction<Route, EndpointConfig<Route, Schemas>>[]
 }>
 
 /**
@@ -106,11 +104,11 @@ export type ContextSearchParams<Schemas extends EndpointConfig<any, any>["schema
 /**
  * Infer the type of body from the provided value in the `EndpointConfig`.
  */
-export type ContextBody<Schemas extends EndpointConfig<any, any>["schemas"]> = Schemas extends { body: ZodObject }
+export type ContextBody<Schemas extends EndpointConfig<any, any>["schemas"]> = [Schemas] extends [{ body: ZodObject }]
     ? { body: z.infer<Schemas["body"]> }
-    : Schemas extends { body: ObjectSchema<any, undefined> }
+    : [Schemas] extends [{ body: ObjectSchema<any, undefined> }]
       ? { body: InferOutput<Schemas["body"]> }
-      : Schemas extends { body: Type<infer Body> }
+      : [Schemas] extends [{ body: Type<infer Body> }]
         ? { body: Body }
         : { body: undefined }
 
@@ -140,6 +138,7 @@ export type RouteHandlerReturn = Response | JsonResponse<unknown>
 export type RequestContext<
     Route extends RoutePattern = RoutePattern,
     Config extends EndpointConfig = EndpointConfig,
+    //Config extends { schemas?: EndpointSchemas } = { schemas: EndpointSchemas },
     Method extends HTTPMethod | HTTPMethod[] = HTTPMethod | HTTPMethod[],
 > = {
     params: ContextParams<NonNullable<Config["schemas"]>, GetRouteParams<Route>>["params"]
@@ -173,12 +172,16 @@ export type GlobalMiddleware = (
 export type MiddlewareFunction<
     Route extends RoutePattern = RoutePattern,
     Config extends EndpointConfig<Route, {}> = EndpointConfig<Route, {}>,
+    //Schemas extends EndpointSchemas | undefined = undefined
 > = (
     ctx: Prettify<RequestContext<Route, { schemas: Config["schemas"] }>>
+    //ctx: Prettify<RequestContext<Route, { schemas: Schemas }>>
 ) =>
     | Response
     | RequestContext<Route, { schemas: Config["schemas"] }>
     | Promise<Response | RequestContext<Route, { schemas: Config["schemas"] }>>
+//| RequestContext<Route, { schemas: Schemas }>
+//| Promise<Response | Prettify<RequestContext<Route, { schemas: Schemas }>>>
 
 /**
  * Defines a route handler function that processes an incoming request and returns a response.
@@ -188,9 +191,6 @@ export type MiddlewareFunction<
 export type RouteHandler<
     Route extends RoutePattern,
     Config extends EndpointConfig<Route, any>,
-    /**
-     * No removal of the `ReturnType` utility type here, as it is used to infer the return type of the handler function.
-     */
     Return extends RouteHandlerReturn = RouteHandlerReturn,
     Method extends HTTPMethod | HTTPMethod[] = HTTPMethod | HTTPMethod[],
 > = (ctx: Prettify<RequestContext<Route, { schemas: NonNullable<Config["schemas"]> }, Method>>) => Return | Promise<Return>
@@ -218,8 +218,10 @@ export interface RouteEndpoint<
 
 /**
  * Infer the HTTP methods defined in the provided array of route endpoints.
+ * @unstable
+ * @todo improve the performance of this type, currently it has exponential complexity due to the recursive conditional types and inference.
  */
-export type InferMethod<Endpoints extends readonly RouteEndpoint<any, any, any>[]> = Endpoints extends (infer Endpoint)[]
+export type InferMethod<Endpoints extends readonly RouteEndpoint<any, any, any, any>[]> = Endpoints extends (infer Endpoint)[]
     ? Endpoint extends RouteEndpoint<infer Method, infer _, infer __>
         ? Method extends HTTPMethod[]
             ? Method[number]
@@ -231,7 +233,7 @@ export type InferMethod<Endpoints extends readonly RouteEndpoint<any, any, any>[
  * Generates an object with HTTP methods available by the router from `createRouter` function.
  * Each method is a function that takes a request and context, returning a promise of a response.
  */
-export type GetHttpHandlers<Endpoints extends readonly RouteEndpoint<any, any, any>[]> = {
+export type GetHttpHandlers<Endpoints extends readonly RouteEndpoint<any, any, any, any>[]> = {
     [Method in InferMethod<Endpoints>]: (req: Request) => Response | Promise<Response>
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import type { ZodObject, z } from "zod"
 import type { RouterError } from "./error.ts"
 import type { HeadersBuilder } from "./headers.ts"
 import type { ObjectSchema, InferOutput, StringSchema, InferInput } from "valibot"
+import { Type } from "arktype"
 
 /**
  * Route pattern must start with a slash and can contain parameters prefixed with a colon.
@@ -63,9 +64,9 @@ export type GetRouteParams<Route extends RoutePattern> = Route extends `/${infer
  * Available schemas validation for an endpoint. It can include body and searchParams schemas.
  */
 export interface EndpointSchemas {
-    body?: ZodObject<any> | ObjectSchema<any, undefined>
-    searchParams?: ZodObject<any> | ObjectSchema<any, undefined>
-    params?: ZodObject<any> | ObjectSchema<any, undefined>
+    body?: ZodObject<any> | ObjectSchema<any, undefined> | Type<{}>
+    searchParams?: ZodObject<any> | ObjectSchema<any, undefined> | Type<{}>
+    params?: ZodObject<any> | ObjectSchema<any, undefined> | Type<{}>
 }
 
 /**
@@ -83,17 +84,24 @@ export type EndpointConfig<
     Schemas extends EndpointSchemas = EndpointSchemas,
 > = Prettify<{
     schemas?: Schemas
-    use?: MiddlewareFunction<Route, EndpointConfig<Route, Schemas>>[]
+    use?: MiddlewareFunction<
+        Route,
+        EndpointConfig<Route, { body: Schemas["body"]; params: Schemas["params"]; searchParams: Schemas["searchParams"] }>
+    >[]
 }>
 
 /**
  * Infer the type of search parameters from the provided value in the `EndpointConfig`.
  */
-export type ContextSearchParams<Schemas extends EndpointConfig<any, any>["schemas"]> = Schemas extends { searchParams: ZodObject }
+export type ContextSearchParams<Schemas extends EndpointConfig<any, any>["schemas"]> = [Schemas] extends [
+    { searchParams: ZodObject },
+]
     ? { searchParams: z.infer<Schemas["searchParams"]> }
-    : Schemas extends { searchParams: ObjectSchema<any, undefined> }
+    : [Schemas] extends [{ searchParams: ObjectSchema<any, undefined> }]
       ? { searchParams: InferOutput<Schemas["searchParams"]> }
-      : { searchParams: URLSearchParams }
+      : [Schemas] extends [{ searchParams: Type<infer SearchParams> }]
+        ? { searchParams: SearchParams }
+        : { searchParams: URLSearchParams }
 
 /**
  * Infer the type of body from the provided value in the `EndpointConfig`.
@@ -102,7 +110,9 @@ export type ContextBody<Schemas extends EndpointConfig<any, any>["schemas"]> = S
     ? { body: z.infer<Schemas["body"]> }
     : Schemas extends { body: ObjectSchema<any, undefined> }
       ? { body: InferOutput<Schemas["body"]> }
-      : { body: undefined }
+      : Schemas extends { body: Type<infer Body> }
+        ? { body: Body }
+        : { body: undefined }
 
 export type ContextParams<Schemas extends EndpointSchemas, Default extends Record<string, string> = Record<string, string>> = [
     Schemas,
@@ -110,7 +120,9 @@ export type ContextParams<Schemas extends EndpointSchemas, Default extends Recor
     ? { params: z.infer<Schemas["params"]> }
     : [Schemas] extends [{ params: ObjectSchema<any, undefined> }]
       ? { params: InferOutput<Schemas["params"]> }
-      : { params: Default }
+      : [Schemas] extends [{ params: Type<infer Params> }]
+        ? { params: Params }
+        : { params: Default }
 
 declare const jsonResponseBrand: unique symbol
 
@@ -284,23 +296,27 @@ export type ToInferSchema<T> = {
     [K in keyof T]: InferSchema<T[K]>
 }
 
+export type ToInferArktype<T> = {
+    [K in keyof T]: T[K] extends Type<infer U> ? U : T[K]
+}
+
 export type RemoveUndefined<T> = {
     [K in keyof T as undefined extends T[K] ? never : K]: T[K]
 }
 
 type HasSchemas<C> =
     C extends EndpointConfig<any, infer Schemas>
-        ? Schemas[keyof Schemas] extends ZodObject<any> | ObjectSchema<any, undefined>
+        ? Schemas[keyof Schemas] extends ZodObject<any> | ObjectSchema<any, undefined> | Type<{}>
             ? true
             : false
         : false
 
 type InferContent<Config extends EndpointConfig<any, any>> =
     Config extends EndpointConfig<any, infer Schemas>
-        ? Schemas[keyof Schemas] extends ZodObject<any>
+        ? Schemas[keyof Schemas] extends ZodObject<any> | ObjectSchema<any, undefined>
             ? RemoveUndefined<ToInferSchema<Schemas>>
-            : Schemas[keyof Schemas] extends ObjectSchema<any, undefined>
-              ? RemoveUndefined<ToInferSchema<Schemas>>
+            : Schemas[keyof Schemas] extends Type<any>
+              ? RemoveUndefined<ToInferArktype<Schemas>>
               : unknown
         : unknown
 

--- a/src/validator/registry.ts
+++ b/src/validator/registry.ts
@@ -31,7 +31,12 @@ export const createValidator = <T>(schema: any): SchemaAdapter<T> => {
                 }
                 if (isArkType(schema)) {
                     const parsed = schema(data)
-                    return parsed instanceof Error
+                    const isError = parsed !== null &&
+                        typeof parsed === "object" &&
+                        "summary" in parsed &&
+                        typeof (parsed as any).summary === "string"
+
+                    return isError
                         ? { success: false, data: null, error: parsed }
                         : { success: true, data: parsed as T, error: null }
                 }

--- a/src/validator/registry.ts
+++ b/src/validator/registry.ts
@@ -1,5 +1,5 @@
 import { safeParse } from "valibot"
-import { isValibotSchema, isZodSchema } from "@/assert.ts"
+import { isValibotSchema, isZodSchema, isArkType } from "@/assert.ts"
 
 export type ValidationResult<T> = { success: true; data: T; error: null } | { success: false; data: null; error: any }
 
@@ -11,23 +11,29 @@ export interface SchemaAdapter<T> {
  * Universal wrapper for Zod, Valibot, ArkType, etc.
  */
 export const createValidator = <T>(schema: any): SchemaAdapter<T> => {
-    if (!isZodSchema(schema) && !isValibotSchema(schema)) {
+    if (!isZodSchema(schema) && !isValibotSchema(schema) && !isArkType(schema)) {
         throw new Error("Unsupported schema type")
     }
     return {
         validate: (data: unknown): ValidationResult<T> => {
             try {
                 if (isZodSchema(schema)) {
-                    const result = schema.safeParse(data)
-                    return result.success
-                        ? { success: true, data: result.data as T, error: null }
-                        : { success: false, data: null, error: result.error }
+                    const parsed = schema.safeParse(data)
+                    return parsed.success
+                        ? { success: true, data: parsed.data as T, error: null }
+                        : { success: false, data: null, error: parsed.error }
                 }
                 if (isValibotSchema(schema)) {
-                    const result = safeParse(schema, data)
-                    return result.success
-                        ? { success: true, data: result.output, error: null }
-                        : { success: false, data: null, error: result.issues }
+                    const parsed = safeParse(schema, data)
+                    return parsed.success
+                        ? { success: true, data: parsed.output, error: null }
+                        : { success: false, data: null, error: parsed.issues }
+                }
+                if (isArkType(schema)) {
+                    const parsed = schema(data)
+                    return parsed instanceof Error
+                        ? { success: false, data: null, error: parsed }
+                        : { success: true, data: parsed as T, error: null }
                 }
                 return { success: false, data: null, error: new Error("Unsupported schema type") }
             } catch (e) {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, vi, beforeEach, expectTypeOf } from "vitest"
-import { never, z } from "zod"
+import { type } from "arktype"
+import { z } from "zod"
 import * as valibot from "valibot"
 import { createRouter } from "@/router.ts"
 import { createEndpoint } from "@/endpoint.ts"
@@ -371,6 +372,78 @@ test("Client type inference with Valibot schemas", async () => {
             schemas: {
                 params: valibot.object({ itemId: valibot.string() }),
                 searchParams: valibot.object({ force: valibot.string() }),
+            },
+        }
+    )
+
+    const router = createRouter([getItem, createItem, deleteItem])
+
+    const client = createClient<typeof router>({
+        baseURL: "http://api.example.com",
+    })
+
+    client.get("/items/:itemId", {
+        params: {
+            itemId: "123",
+        },
+    })
+
+    client.get("/items/:itemId", {
+        params: { itemId: "123" },
+    })
+
+    const item = await client.get("/items/:itemId", {
+        params: { itemId: "123" },
+    })
+    expectTypeOf<typeof item>().toEqualTypeOf<JsonResponse<{ method: "GET" }>>()
+
+    const newItem = await client.post("/items", {
+        body: JSON.stringify({ name: "New Item" }),
+        headers: { "Content-Type": "application/json" },
+    })
+    expectTypeOf<typeof newItem>().toEqualTypeOf<JsonResponse<{ method: "POST" }>>()
+
+    const deletedItem = await client.delete("/items/:itemId", {
+        params: { itemId: "123" },
+        searchParams: { force: "true" },
+    })
+    expectTypeOf<typeof deletedItem>().toEqualTypeOf<JsonResponse<{ method: "DELETE" }>>()
+})
+
+test("Client type inference with Arktype schemas", async () => {
+    const getItem = createEndpoint(
+        "GET",
+        "/items/:itemId",
+        (ctx) => {
+            return ctx.json({ method: ctx.method })
+        },
+        {
+            schemas: {
+                params: type({
+                    itemId: "string",
+                }),
+            },
+        }
+    )
+
+    const createItem = createEndpoint("POST", "/items", (ctx) => {
+        return ctx.json({ method: ctx.method })
+    })
+
+    const deleteItem = createEndpoint(
+        "DELETE",
+        "/items/:itemId",
+        (ctx) => {
+            return ctx.json({ method: ctx.method })
+        },
+        {
+            schemas: {
+                params: type({
+                    itemId: "string",
+                }),
+                searchParams: type({
+                    force: "string",
+                }),
             },
         }
     )

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -4,6 +4,7 @@ import { describe, test } from "vitest"
 import { createRouter } from "@/router.ts"
 import { createEndpoint, createEndpointConfig } from "@/endpoint.ts"
 import type { HTTPMethod, RoutePattern } from "@/types.ts"
+import { type } from "arktype"
 
 describe("createEndpoint", () => {
     describe("With valid configuration", () => {
@@ -168,7 +169,7 @@ describe("createEndpoint", () => {
             })
         })
 
-        describe("Valibot body schema", () => {
+        describe("Arktype body schema", () => {
             const endpoint = createEndpoint(
                 "POST",
                 "/auth/credentials",
@@ -177,9 +178,9 @@ describe("createEndpoint", () => {
                 },
                 {
                     schemas: {
-                        body: valibot.object({
-                            username: valibot.string(),
-                            password: valibot.string(),
+                        body: type({
+                            username: "string",
+                            password: "string",
                         }),
                     },
                 }
@@ -284,6 +285,41 @@ describe("createEndpoint", () => {
             })
         })
 
+        describe("Arktype searchParams schema", () => {
+            const endpoint = createEndpoint(
+                "GET",
+                "/auth/:oauth",
+                (ctx) => {
+                    return Response.json({ searchParams: ctx.searchParams })
+                },
+                {
+                    schemas: {
+                        searchParams: type({
+                            state: "string",
+                            code: "string",
+                        }),
+                    },
+                }
+            )
+
+            const { GET } = createRouter([endpoint])
+
+            test("With valid searchParams", async ({ expect }) => {
+                const get = await GET(new Request("https://example.com/auth/google?state=123abc&code=123"))
+                expect(get.ok).toBe(true)
+                expect(await get.json()).toEqual({
+                    searchParams: { state: "123abc", code: "123" },
+                })
+            })
+
+            test("With invalid searchParams", async ({ expect }) => {
+                const get = await GET(new Request("https://example.com/auth/google?state=123abc", { method: "GET" }))
+                expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
+                expect(get.status).toBe(422)
+                expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
+            })
+        })
+
         describe("Zod params schema", () => {
             const config = createEndpointConfig("/signIn/:oauth", {
                 schemas: {
@@ -362,6 +398,71 @@ describe("createEndpoint", () => {
                 schemas: {
                     params: valibot.object({
                         typeId: valibot.enum({ token: "token", code: "code" }),
+                    }),
+                },
+            })
+
+            const endpoint = createEndpoint(
+                "GET",
+                "/signIn/:oauth",
+                (ctx) => {
+                    const oauth = ctx.params.oauth
+                    return Response.json({ oauth })
+                },
+                config
+            )
+
+            const inferEndpoint = createEndpoint(
+                "GET",
+                "/type/:typeId",
+                (ctx) => {
+                    return Response.json({ typeId: ctx.params.typeId })
+                },
+                inferConfig
+            )
+
+            const { GET } = createRouter([endpoint, inferEndpoint])
+
+            test("With valid params", async ({ expect }) => {
+                const get = await GET(new Request("https://example.com/signIn/google"))
+                expect(get.ok).toBe(true)
+                expect(await get.json()).toEqual({ oauth: "google" })
+            })
+
+            test("With invalid params", async ({ expect }) => {
+                const get = await GET(new Request("https://example.com/signIn/facebook"))
+                expect(get.status).toBe(422)
+                expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
+                expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
+            })
+
+            test("With inferred params", async ({ expect }) => {
+                const get = await GET(new Request("https://example.com/type/token"))
+                expect(get.ok).toBe(true)
+                expect(await get.json()).toEqual({ typeId: "token" })
+            })
+
+            test("With invalid inferred params", async ({ expect }) => {
+                const get = await GET(new Request("https://example.com/type/invalid"))
+                expect(get.status).toBe(422)
+                expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
+                expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
+            })
+        })
+
+        describe("Arktype params schema", () => {
+            const config = createEndpointConfig("/signIn/:oauth", {
+                schemas: {
+                    params: type({
+                        oauth: type.enumerated("google", "github")
+                    }),
+                },
+            })
+
+            const inferConfig = createEndpointConfig("/type/:typeId", {
+                schemas: {
+                    params: type({
+                        typeId: type.enumerated("token", "code"),
                     }),
                 },
             })

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -366,10 +366,15 @@ describe("createEndpoint", () => {
                 },
             })
 
-            const endpoint = createEndpoint("GET", "/signIn/:oauth", (ctx) => {
-                const oauth = ctx.params.oauth
-                return Response.json({ oauth })
-            })
+            const endpoint = createEndpoint(
+                "GET",
+                "/signIn/:oauth",
+                (ctx) => {
+                    const oauth = ctx.params.oauth
+                    return Response.json({ oauth })
+                },
+                config
+            )
 
             const inferEndpoint = createEndpoint(
                 "GET",

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -168,6 +168,52 @@ describe("createEndpoint", () => {
             })
         })
 
+        describe("Valibot body schema", () => {
+            const endpoint = createEndpoint(
+                "POST",
+                "/auth/credentials",
+                (ctx) => {
+                    return Response.json({ body: ctx.body })
+                },
+                {
+                    schemas: {
+                        body: valibot.object({
+                            username: valibot.string(),
+                            password: valibot.string(),
+                        }),
+                    },
+                }
+            )
+            const { POST } = createRouter([endpoint])
+
+            test("With valid body", async ({ expect }) => {
+                const post = await POST(
+                    new Request("https://example.com/auth/credentials", {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({ username: "John", password: "secret" }),
+                    })
+                )
+                expect(post.ok).toBe(true)
+                expect(await post.json()).toEqual({
+                    body: { username: "John", password: "secret" },
+                })
+            })
+
+            test("With invalid body", async ({ expect }) => {
+                const post = await POST(
+                    new Request("https://example.com/auth/credentials", {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({ username: "John" }),
+                    })
+                )
+                expect(post.status).toBe(422)
+                expect(await post.json()).toMatchObject({ error: "validation_error", details: {} })
+                expect(post.statusText).toBe("UNPROCESSABLE_ENTITY")
+            })
+        })
+
         describe("Zod searchParams schema", () => {
             const endpoint = createEndpoint(
                 "GET",
@@ -320,15 +366,10 @@ describe("createEndpoint", () => {
                 },
             })
 
-            const endpoint = createEndpoint(
-                "GET",
-                "/signIn/:oauth",
-                (ctx) => {
-                    const oauth = ctx.params.oauth
-                    return Response.json({ oauth })
-                },
-                config
-            )
+            const endpoint = createEndpoint("GET", "/signIn/:oauth", (ctx) => {
+                const oauth = ctx.params.oauth
+                return Response.json({ oauth })
+            })
 
             const inferEndpoint = createEndpoint(
                 "GET",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "allowImportingTsExtensions": true,
+    "noErrorTruncation": true,
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
## Description

This pull request adds ArkType schema validation support alongside the existing Zod and Valibot integrations.

Aura Router now supports three schema validation libraries for endpoint validation across:
- request body
- route parameters
- search parameters

---

## Changes

- Add ArkType schema validation support
- Extend endpoint schema compatibility to support:
  - Zod
  - Valibot
  - ArkType
- Preserve type inference across router and client APIs

---

## TypeScript Limitation

> [!NOTE]
> During the implementation of this feature, some type definitions triggered the following TypeScript compiler error:
>
> `TS2589: Type instantiation is excessively deep and possibly infinite`
>
> A follow-up pull request will focus on reducing type complexity and improving inference stability for deeply nested generic types.

---

## Usage

```ts
import { type } from "arktype"

import {
  createEndpoint,
  createRouter,
  createClient,
} from "@aura-stack/router"

const credentials = createEndpoint(
  "POST",
  "/auth/credentials",
  (ctx) => {
    return Response.json({
      body: ctx.body,
    })
  },
  {
    schemas: {
      body: type({
        username: "string",
        password: "string",
      }),
    },
  }
)

const router = createRouter([credentials])

const client = createClient<typeof router>({
  baseURL: "http://api.example.com",
})

await client.post("/auth/credentials", {
  body: {
    username: "johndoe",
    password: "1234567890",
  },
})
```