### PR TITLE
feat(router): support `Typebox` schema validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
   "peerDependencies": {
     "arktype": "^2.0.0",
     "valibot": "^1.4.0",
-    "zod": "^4.1.11"
+    "zod": "^4.1.11",
+    "typebox": "^1.1.38"
   },
   "peerDependenciesMeta": {
     "zod": {
@@ -113,6 +114,9 @@
       "optional": true
     },
     "arktype": {
+      "optional": true
+    },
+    "typebox": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       cookie:
         specifier: ^1.1.1
         version: 1.1.1
+      typebox:
+        specifier: ^1.1.38
+        version: 1.1.38
       valibot:
         specifier: ^1.4.0
         version: 1.4.0(typescript@5.9.3)
@@ -2615,6 +2618,9 @@ packages:
     resolution: {integrity: sha512-VuI5OKl+MaUO9UIW3rXKoPgHI3X40ZgB/j12VY6h98Ae1mCBihjPvhOPeJWlxCYcmSbmeZt5ZKkK0dsVtp+6pA==}
     peerDependencies:
       typescript: ^5.5.0
+
+  typebox@1.1.38:
+    resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -5381,6 +5387,8 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
+
+  typebox@1.1.38: {}
 
   typescript@5.9.3: {}
 

--- a/src/@types/client.ts
+++ b/src/@types/client.ts
@@ -1,17 +1,22 @@
 import type { Type } from "arktype"
 import type { ObjectSchema } from "valibot"
+import type { Static, TObject } from "typebox"
 import type { RequestHeaders } from "@/@types/http.ts"
 import type { ZodObject, ZodTypeAny, infer as Infer } from "zod"
 import type { InferValibotSchema, RoutePattern, EndpointConfig, Prettify, RouteEndpoint } from "@/@types/types.ts"
 
-export type InferSchema<T> = T extends ZodTypeAny ? Infer<T> : T extends ObjectSchema<any, undefined> ? InferValibotSchema<T> : T
+export type InferSchema<T> = T extends ZodTypeAny
+    ? Infer<T>
+    : T extends ObjectSchema<any, undefined>
+      ? InferValibotSchema<T>
+      : T extends TObject
+        ? Static<T>
+        : T extends Type<infer U>
+          ? U
+          : T
 
 export type ToInferSchema<T> = {
     [K in keyof T]: InferSchema<T[K]>
-}
-
-export type ToInferArktype<T> = {
-    [K in keyof T]: T[K] extends Type<infer U> ? U : T[K]
 }
 
 export type RemoveUndefined<T> = {
@@ -20,18 +25,16 @@ export type RemoveUndefined<T> = {
 
 type HasSchemas<C> =
     C extends EndpointConfig<any, infer Schemas>
-        ? Schemas[keyof Schemas] extends ZodObject<any> | ObjectSchema<any, undefined> | Type<{}>
+        ? Schemas[keyof Schemas] extends ZodObject<any> | ObjectSchema<any, undefined> | Type<{}> | TObject<{}>
             ? true
             : false
         : false
 
 type InferContent<Config extends EndpointConfig<any, any>> =
     Config extends EndpointConfig<any, infer Schemas>
-        ? Schemas[keyof Schemas] extends ZodObject<any> | ObjectSchema<any, undefined>
+        ? Schemas[keyof Schemas] extends ZodObject<any> | ObjectSchema<any, undefined> | Type<{}> | TObject<{}>
             ? RemoveUndefined<ToInferSchema<Schemas>>
-            : Schemas[keyof Schemas] extends Type<any>
-              ? RemoveUndefined<ToInferArktype<Schemas>>
-              : unknown
+            : unknown
         : unknown
 
 /**

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -1,4 +1,5 @@
 import type { Type } from "arktype"
+import type { Static, TObject } from "typebox"
 import type { ZodObject, z } from "zod"
 import type { ObjectSchema } from "valibot"
 import type { RouterError } from "@/error.ts"
@@ -43,9 +44,9 @@ export type GetRouteParams<Route extends RoutePattern> = Route extends `/${infer
  * Available schemas validation for an endpoint. It can include body and searchParams schemas.
  */
 export interface EndpointSchemas {
-    body?: ZodObject<any> | ObjectSchema<any, undefined> | Type<{}>
-    searchParams?: ZodObject<any> | ObjectSchema<any, undefined> | Type<{}>
-    params?: ZodObject<any> | ObjectSchema<any, undefined> | Type<{}>
+    body?: ZodObject<any> | ObjectSchema<any, undefined> | Type<{}> | TObject<{}>
+    searchParams?: ZodObject<any> | ObjectSchema<any, undefined> | Type<{}> | TObject<{}>
+    params?: ZodObject<any> | ObjectSchema<any, undefined> | Type<{}> | TObject<{}>
 }
 
 /**
@@ -80,7 +81,9 @@ type UnwrapSchema<S, Fallback> = [S] extends [ZodObject<any>]
       ? InferValibotSchema<S>
       : [S] extends [Type<infer T>]
         ? T
-        : Fallback
+        : [S] extends [TObject]
+          ? Static<S>
+          : Fallback
 
 /**
  * Infer the type of search parameters from the provided value in the `EndpointConfig`.

--- a/src/validator/registry.ts
+++ b/src/validator/registry.ts
@@ -1,7 +1,7 @@
 import { safeParse } from "valibot"
 import { isValibotSchema, isZodSchema, isArkType } from "@/assert.ts"
-import { IsObject } from "typebox";
-import { Check } from "typebox/value";
+import { IsObject } from "typebox"
+import { Check } from "typebox/value"
 
 export type ValidationResult<T> = { success: true; data: T; error: null } | { success: false; data: null; error: any }
 
@@ -43,7 +43,7 @@ export const createValidator = <T>(schema: any): SchemaAdapter<T> => {
                         ? { success: false, data: null, error: parsed }
                         : { success: true, data: parsed as T, error: null }
                 }
-                if(IsObject(schema)) {
+                if (IsObject(schema)) {
                     const isValid = Check(schema, data)
                     return isValid
                         ? { success: true, data: data as T, error: null }

--- a/src/validator/registry.ts
+++ b/src/validator/registry.ts
@@ -1,5 +1,7 @@
 import { safeParse } from "valibot"
 import { isValibotSchema, isZodSchema, isArkType } from "@/assert.ts"
+import { IsObject } from "typebox";
+import { Check } from "typebox/value";
 
 export type ValidationResult<T> = { success: true; data: T; error: null } | { success: false; data: null; error: any }
 
@@ -11,7 +13,7 @@ export interface SchemaAdapter<T> {
  * Universal wrapper for Zod, Valibot, ArkType, etc.
  */
 export const createValidator = <T>(schema: any): SchemaAdapter<T> => {
-    if (!isZodSchema(schema) && !isValibotSchema(schema) && !isArkType(schema)) {
+    if (!isZodSchema(schema) && !isValibotSchema(schema) && !isArkType(schema) && !IsObject(schema)) {
         throw new Error("Unsupported schema type")
     }
     return {
@@ -40,6 +42,12 @@ export const createValidator = <T>(schema: any): SchemaAdapter<T> => {
                     return isError
                         ? { success: false, data: null, error: parsed }
                         : { success: true, data: parsed as T, error: null }
+                }
+                if(IsObject(schema)) {
+                    const isValid = Check(schema, data)
+                    return isValid
+                        ? { success: true, data: data as T, error: null }
+                        : { success: false, data: null, error: new Error("Validation failed") }
                 }
                 return { success: false, data: null, error: new Error("Unsupported schema type") }
             } catch (e) {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, vi, beforeEach, expectTypeOf } from "vitest"
 import { type } from "arktype"
 import { z } from "zod"
 import * as valibot from "valibot"
+import * as typebox from "typebox"
 import { createRouter } from "@/router.ts"
 import { createEndpoint } from "@/endpoint.ts"
 import { createClient } from "@/client.ts"
@@ -443,6 +444,84 @@ test("Client type inference with Arktype schemas", async () => {
                 }),
                 searchParams: type({
                     force: "string",
+                }),
+            },
+        }
+    )
+
+    const router = createRouter([getItem, createItem, deleteItem])
+
+    const client = createClient<typeof router>({
+        baseURL: "http://api.example.com",
+    })
+
+    client.get("/items/:itemId", {
+        params: {
+            itemId: "123",
+        },
+    })
+
+    client.get("/items/:itemId", {
+        params: {
+            itemId: "123",
+        },
+    })
+
+    client.get("/items/:itemId", {
+        params: { itemId: "123" },
+    })
+
+    const item = await client.get("/items/:itemId", {
+        params: { itemId: "123" },
+    })
+    expectTypeOf<typeof item>().toEqualTypeOf<JsonResponse<{ method: "GET" }>>()
+
+    const newItem = await client.post("/items", {
+        body: JSON.stringify({ name: "New Item" }),
+        headers: { "Content-Type": "application/json" },
+    })
+    expectTypeOf<typeof newItem>().toEqualTypeOf<JsonResponse<{ method: "POST" }>>()
+
+    const deletedItem = await client.delete("/items/:itemId", {
+        params: { itemId: "123" },
+        searchParams: { force: "true" },
+    })
+    expectTypeOf<typeof deletedItem>().toEqualTypeOf<JsonResponse<{ method: "DELETE" }>>()
+})
+
+test("Client type inference with TypeBox schemas", async () => {
+    const getItem = createEndpoint(
+        "GET",
+        "/items/:itemId",
+        (ctx) => {
+            return ctx.json({ method: ctx.method })
+        },
+        {
+            schemas: {
+                params: typebox.Object({
+                    itemId: typebox.String(),
+                }),
+            },
+        }
+    )
+
+    const createItem = createEndpoint("POST", "/items", (ctx) => {
+        return ctx.json({ method: ctx.method })
+    })
+
+    const deleteItem = createEndpoint(
+        "DELETE",
+        "/items/:itemId",
+        (ctx) => {
+            return ctx.json({ method: ctx.method })
+        },
+        {
+            schemas: {
+                params: typebox.Object({
+                    itemId: typebox.String(),
+                }),
+                searchParams: typebox.Object({
+                    force: typebox.String(),
                 }),
             },
         }

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -229,7 +229,7 @@ describe("createEndpoint", () => {
                             body: typebox.Object({
                                 username: typebox.String(),
                                 password: typebox.String(),
-                            })
+                            }),
                         },
                     }
                 )

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -1,5 +1,6 @@
 import z from "zod"
 import * as valibot from "valibot"
+import * as typebox from "typebox"
 import { type } from "arktype"
 import { describe, test } from "vitest"
 import { createRouter } from "@/router.ts"
@@ -77,441 +78,593 @@ describe("createEndpoint", () => {
     })
 
     describe("With schemas", () => {
-        describe("Zod body schema", () => {
-            const endpoint = createEndpoint(
-                "POST",
-                "/auth/credentials",
-                (ctx) => {
-                    return Response.json({ body: ctx.body })
-                },
-                {
-                    schemas: {
-                        body: z.object({
-                            username: z.string(),
-                            password: z.string(),
-                        }),
+        describe("With body", () => {
+            describe("Zod body schema", () => {
+                const endpoint = createEndpoint(
+                    "POST",
+                    "/auth/credentials",
+                    (ctx) => {
+                        return Response.json({ body: ctx.body })
                     },
-                }
-            )
-            const { POST } = createRouter([endpoint])
-
-            test("With valid body", async ({ expect }) => {
-                const post = await POST(
-                    new Request("https://example.com/auth/credentials", {
-                        method: "POST",
-                        headers: { "Content-Type": "application/json" },
-                        body: JSON.stringify({ username: "John", password: "secret" }),
-                    })
+                    {
+                        schemas: {
+                            body: z.object({
+                                username: z.string(),
+                                password: z.string(),
+                            }),
+                        },
+                    }
                 )
-                expect(post.ok).toBe(true)
-                expect(await post.json()).toEqual({
-                    body: { username: "John", password: "secret" },
+                const { POST } = createRouter([endpoint])
+
+                test("With valid body", async ({ expect }) => {
+                    const post = await POST(
+                        new Request("https://example.com/auth/credentials", {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({ username: "John", password: "secret" }),
+                        })
+                    )
+                    expect(post.ok).toBe(true)
+                    expect(await post.json()).toEqual({
+                        body: { username: "John", password: "secret" },
+                    })
+                })
+
+                test("With invalid body", async ({ expect }) => {
+                    const post = await POST(
+                        new Request("https://example.com/auth/credentials", {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({ username: "John" }),
+                        })
+                    )
+                    expect(post.status).toBe(422)
+                    expect(await post.json()).toMatchObject({ error: "validation_error", details: {} })
+                    expect(post.statusText).toBe("UNPROCESSABLE_ENTITY")
                 })
             })
 
-            test("With invalid body", async ({ expect }) => {
-                const post = await POST(
-                    new Request("https://example.com/auth/credentials", {
-                        method: "POST",
-                        headers: { "Content-Type": "application/json" },
-                        body: JSON.stringify({ username: "John" }),
-                    })
-                )
-                expect(post.status).toBe(422)
-                expect(await post.json()).toMatchObject({ error: "validation_error", details: {} })
-                expect(post.statusText).toBe("UNPROCESSABLE_ENTITY")
-            })
-        })
-
-        describe("Valibot body schema", () => {
-            const endpoint = createEndpoint(
-                "POST",
-                "/auth/credentials",
-                (ctx) => {
-                    return Response.json({ body: ctx.body })
-                },
-                {
-                    schemas: {
-                        body: valibot.object({
-                            username: valibot.string(),
-                            password: valibot.string(),
-                        }),
+            describe("Valibot body schema", () => {
+                const endpoint = createEndpoint(
+                    "POST",
+                    "/auth/credentials",
+                    (ctx) => {
+                        return Response.json({ body: ctx.body })
                     },
-                }
-            )
-            const { POST } = createRouter([endpoint])
-
-            test("With valid body", async ({ expect }) => {
-                const post = await POST(
-                    new Request("https://example.com/auth/credentials", {
-                        method: "POST",
-                        headers: { "Content-Type": "application/json" },
-                        body: JSON.stringify({ username: "John", password: "secret" }),
-                    })
+                    {
+                        schemas: {
+                            body: valibot.object({
+                                username: valibot.string(),
+                                password: valibot.string(),
+                            }),
+                        },
+                    }
                 )
-                expect(post.ok).toBe(true)
-                expect(await post.json()).toEqual({
-                    body: { username: "John", password: "secret" },
+                const { POST } = createRouter([endpoint])
+
+                test("With valid body", async ({ expect }) => {
+                    const post = await POST(
+                        new Request("https://example.com/auth/credentials", {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({ username: "John", password: "secret" }),
+                        })
+                    )
+                    expect(post.ok).toBe(true)
+                    expect(await post.json()).toEqual({
+                        body: { username: "John", password: "secret" },
+                    })
+                })
+
+                test("With invalid body", async ({ expect }) => {
+                    const post = await POST(
+                        new Request("https://example.com/auth/credentials", {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({ username: "John" }),
+                        })
+                    )
+                    expect(post.status).toBe(422)
+                    expect(await post.json()).toMatchObject({ error: "validation_error", details: {} })
+                    expect(post.statusText).toBe("UNPROCESSABLE_ENTITY")
                 })
             })
 
-            test("With invalid body", async ({ expect }) => {
-                const post = await POST(
-                    new Request("https://example.com/auth/credentials", {
-                        method: "POST",
-                        headers: { "Content-Type": "application/json" },
-                        body: JSON.stringify({ username: "John" }),
-                    })
+            describe("Arktype body schema", () => {
+                const endpoint = createEndpoint(
+                    "POST",
+                    "/auth/credentials",
+                    (ctx) => {
+                        return Response.json({ body: ctx.body })
+                    },
+                    {
+                        schemas: {
+                            body: type({
+                                username: "string",
+                                password: "string",
+                            }),
+                        },
+                    }
                 )
-                expect(post.status).toBe(422)
-                expect(await post.json()).toMatchObject({ error: "validation_error", details: {} })
-                expect(post.statusText).toBe("UNPROCESSABLE_ENTITY")
-            })
-        })
+                const { POST } = createRouter([endpoint])
 
-        describe("Arktype body schema", () => {
-            const endpoint = createEndpoint(
-                "POST",
-                "/auth/credentials",
-                (ctx) => {
-                    return Response.json({ body: ctx.body })
-                },
-                {
-                    schemas: {
-                        body: type({
-                            username: "string",
-                            password: "string",
-                        }),
-                    },
-                }
-            )
-            const { POST } = createRouter([endpoint])
-
-            test("With valid body", async ({ expect }) => {
-                const post = await POST(
-                    new Request("https://example.com/auth/credentials", {
-                        method: "POST",
-                        headers: { "Content-Type": "application/json" },
-                        body: JSON.stringify({ username: "John", password: "secret" }),
+                test("With valid body", async ({ expect }) => {
+                    const post = await POST(
+                        new Request("https://example.com/auth/credentials", {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({ username: "John", password: "secret" }),
+                        })
+                    )
+                    expect(post.ok).toBe(true)
+                    expect(await post.json()).toEqual({
+                        body: { username: "John", password: "secret" },
                     })
-                )
-                expect(post.ok).toBe(true)
-                expect(await post.json()).toEqual({
-                    body: { username: "John", password: "secret" },
+                })
+
+                test("With invalid body", async ({ expect }) => {
+                    const post = await POST(
+                        new Request("https://example.com/auth/credentials", {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({ username: "John" }),
+                        })
+                    )
+                    expect(post.status).toBe(422)
+                    expect(await post.json()).toMatchObject({ error: "validation_error", details: {} })
+                    expect(post.statusText).toBe("UNPROCESSABLE_ENTITY")
                 })
             })
 
-            test("With invalid body", async ({ expect }) => {
-                const post = await POST(
-                    new Request("https://example.com/auth/credentials", {
-                        method: "POST",
-                        headers: { "Content-Type": "application/json" },
-                        body: JSON.stringify({ username: "John" }),
+            describe("Typebox body schema", () => {
+                const endpoint = createEndpoint(
+                    "POST",
+                    "/auth/credentials",
+                    (ctx) => {
+                        return Response.json({ body: ctx.body })
+                    },
+                    {
+                        schemas: {
+                            body: typebox.Object({
+                                username: typebox.String(),
+                                password: typebox.String(),
+                            })
+                        },
+                    }
+                )
+                const { POST } = createRouter([endpoint])
+
+                test("With valid body", async ({ expect }) => {
+                    const post = await POST(
+                        new Request("https://example.com/auth/credentials", {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({ username: "John", password: "secret" }),
+                        })
+                    )
+                    expect(post.ok).toBe(true)
+                    expect(await post.json()).toEqual({
+                        body: { username: "John", password: "secret" },
                     })
+                })
+
+                test("With invalid body", async ({ expect }) => {
+                    const post = await POST(
+                        new Request("https://example.com/auth/credentials", {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({ username: "John" }),
+                        })
+                    )
+                    expect(post.status).toBe(422)
+                    expect(await post.json()).toMatchObject({ error: "validation_error", details: {} })
+                    expect(post.statusText).toBe("UNPROCESSABLE_ENTITY")
+                })
+            })
+        })
+
+        describe("With searchParams", () => {
+            describe("Zod searchParams schema", () => {
+                const endpoint = createEndpoint(
+                    "GET",
+                    "/auth/:oauth",
+                    (ctx) => {
+                        return Response.json({ searchParams: ctx.searchParams })
+                    },
+                    {
+                        schemas: {
+                            searchParams: z.object({
+                                state: z.string(),
+                                code: z.string(),
+                            }),
+                        },
+                    }
                 )
-                expect(post.status).toBe(422)
-                expect(await post.json()).toMatchObject({ error: "validation_error", details: {} })
-                expect(post.statusText).toBe("UNPROCESSABLE_ENTITY")
-            })
-        })
 
-        describe("Zod searchParams schema", () => {
-            const endpoint = createEndpoint(
-                "GET",
-                "/auth/:oauth",
-                (ctx) => {
-                    return Response.json({ searchParams: ctx.searchParams })
-                },
-                {
-                    schemas: {
-                        searchParams: z.object({
-                            state: z.string(),
-                            code: z.string(),
-                        }),
-                    },
-                }
-            )
+                const { GET } = createRouter([endpoint])
 
-            const { GET } = createRouter([endpoint])
+                test("With valid searchParams", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/auth/google?state=123abc&code=123"))
+                    expect(get.ok).toBe(true)
+                    expect(await get.json()).toEqual({
+                        searchParams: { state: "123abc", code: "123" },
+                    })
+                })
 
-            test("With valid searchParams", async ({ expect }) => {
-                const get = await GET(new Request("https://example.com/auth/google?state=123abc&code=123"))
-                expect(get.ok).toBe(true)
-                expect(await get.json()).toEqual({
-                    searchParams: { state: "123abc", code: "123" },
+                test("With invalid searchParams", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/auth/google?state=123abc", { method: "GET" }))
+                    expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
+                    expect(get.status).toBe(422)
+                    expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
                 })
             })
 
-            test("With invalid searchParams", async ({ expect }) => {
-                const get = await GET(new Request("https://example.com/auth/google?state=123abc", { method: "GET" }))
-                expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
-                expect(get.status).toBe(422)
-                expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
-            })
-        })
-
-        describe("Valibot searchParams schema", () => {
-            const endpoint = createEndpoint(
-                "GET",
-                "/auth/:oauth",
-                (ctx) => {
-                    return Response.json({ searchParams: ctx.searchParams })
-                },
-                {
-                    schemas: {
-                        searchParams: valibot.object({
-                            state: valibot.string(),
-                            code: valibot.string(),
-                        }),
+            describe("Valibot searchParams schema", () => {
+                const endpoint = createEndpoint(
+                    "GET",
+                    "/auth/:oauth",
+                    (ctx) => {
+                        return Response.json({ searchParams: ctx.searchParams })
                     },
-                }
-            )
+                    {
+                        schemas: {
+                            searchParams: valibot.object({
+                                state: valibot.string(),
+                                code: valibot.string(),
+                            }),
+                        },
+                    }
+                )
 
-            const { GET } = createRouter([endpoint])
+                const { GET } = createRouter([endpoint])
 
-            test("With valid searchParams", async ({ expect }) => {
-                const get = await GET(new Request("https://example.com/auth/google?state=123abc&code=123"))
-                expect(get.ok).toBe(true)
-                expect(await get.json()).toEqual({
-                    searchParams: { state: "123abc", code: "123" },
+                test("With valid searchParams", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/auth/google?state=123abc&code=123"))
+                    expect(get.ok).toBe(true)
+                    expect(await get.json()).toEqual({
+                        searchParams: { state: "123abc", code: "123" },
+                    })
+                })
+
+                test("With invalid searchParams", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/auth/google?state=123abc", { method: "GET" }))
+                    expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
+                    expect(get.status).toBe(422)
+                    expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
                 })
             })
 
-            test("With invalid searchParams", async ({ expect }) => {
-                const get = await GET(new Request("https://example.com/auth/google?state=123abc", { method: "GET" }))
-                expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
-                expect(get.status).toBe(422)
-                expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
-            })
-        })
-
-        describe("Arktype searchParams schema", () => {
-            const endpoint = createEndpoint(
-                "GET",
-                "/auth/:oauth",
-                (ctx) => {
-                    return Response.json({ searchParams: ctx.searchParams })
-                },
-                {
-                    schemas: {
-                        searchParams: type({
-                            state: "string",
-                            code: "string",
-                        }),
+            describe("Arktype searchParams schema", () => {
+                const endpoint = createEndpoint(
+                    "GET",
+                    "/auth/:oauth",
+                    (ctx) => {
+                        return Response.json({ searchParams: ctx.searchParams })
                     },
-                }
-            )
+                    {
+                        schemas: {
+                            searchParams: type({
+                                state: "string",
+                                code: "string",
+                            }),
+                        },
+                    }
+                )
 
-            const { GET } = createRouter([endpoint])
+                const { GET } = createRouter([endpoint])
 
-            test("With valid searchParams", async ({ expect }) => {
-                const get = await GET(new Request("https://example.com/auth/google?state=123abc&code=123"))
-                expect(get.ok).toBe(true)
-                expect(await get.json()).toEqual({
-                    searchParams: { state: "123abc", code: "123" },
+                test("With valid searchParams", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/auth/google?state=123abc&code=123"))
+                    expect(get.ok).toBe(true)
+                    expect(await get.json()).toEqual({
+                        searchParams: { state: "123abc", code: "123" },
+                    })
+                })
+
+                test("With invalid searchParams", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/auth/google?state=123abc", { method: "GET" }))
+                    expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
+                    expect(get.status).toBe(422)
+                    expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
                 })
             })
 
-            test("With invalid searchParams", async ({ expect }) => {
-                const get = await GET(new Request("https://example.com/auth/google?state=123abc", { method: "GET" }))
-                expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
-                expect(get.status).toBe(422)
-                expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
+            describe("Typebox searchParams schema", () => {
+                const endpoint = createEndpoint(
+                    "GET",
+                    "/auth/:oauth",
+                    (ctx) => {
+                        return Response.json({ searchParams: ctx.searchParams })
+                    },
+                    {
+                        schemas: {
+                            searchParams: typebox.Object({
+                                state: typebox.String(),
+                                code: typebox.String(),
+                            }),
+                        },
+                    }
+                )
+
+                const { GET } = createRouter([endpoint])
+
+                test("With valid searchParams", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/auth/google?state=123abc&code=123"))
+                    expect(get.ok).toBe(true)
+                    expect(await get.json()).toEqual({
+                        searchParams: { state: "123abc", code: "123" },
+                    })
+                })
+
+                test("With invalid searchParams", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/auth/google?state=123abc", { method: "GET" }))
+                    expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
+                    expect(get.status).toBe(422)
+                    expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
+                })
             })
         })
 
-        describe("Zod params schema", () => {
-            const config = createEndpointConfig("/signIn/:oauth", {
-                schemas: {
-                    params: z.object({
-                        oauth: z.enum(["google", "github"]),
-                    }),
-                },
+        describe("With params", () => {
+            describe("Zod params schema", () => {
+                const config = createEndpointConfig("/signIn/:oauth", {
+                    schemas: {
+                        params: z.object({
+                            oauth: z.enum(["google", "github"]),
+                        }),
+                    },
+                })
+
+                const inferConfig = createEndpointConfig("/type/:typeId", {
+                    schemas: {
+                        params: z.object({
+                            typeId: z.enum(["token", "code"]),
+                        }),
+                    },
+                })
+
+                const endpoint = createEndpoint(
+                    "GET",
+                    "/signIn/:oauth",
+                    (ctx) => {
+                        const oauth = ctx.params.oauth
+                        return Response.json({ oauth })
+                    },
+                    config
+                )
+
+                const inferEndpoint = createEndpoint(
+                    "GET",
+                    "/type/:typeId",
+                    (ctx) => {
+                        return Response.json({ typeId: ctx.params.typeId })
+                    },
+                    inferConfig
+                )
+
+                const { GET } = createRouter([endpoint, inferEndpoint])
+
+                test("With valid params", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/signIn/google"))
+                    expect(get.ok).toBe(true)
+                    expect(await get.json()).toEqual({ oauth: "google" })
+                })
+
+                test("With invalid params", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/signIn/facebook"))
+                    expect(get.status).toBe(422)
+                    expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
+                    expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
+                })
+
+                test("With inferred params", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/type/token"))
+                    expect(get.ok).toBe(true)
+                    expect(await get.json()).toEqual({ typeId: "token" })
+                })
+
+                test("With invalid inferred params", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/type/invalid"))
+                    expect(get.status).toBe(422)
+                    expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
+                    expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
+                })
             })
 
-            const inferConfig = createEndpointConfig("/type/:typeId", {
-                schemas: {
-                    params: z.object({
-                        typeId: z.enum(["token", "code"]),
-                    }),
-                },
+            describe("Valibot params schema", () => {
+                const config = createEndpointConfig("/signIn/:oauth", {
+                    schemas: {
+                        params: valibot.object({
+                            oauth: valibot.enum({ google: "google", github: "github" }),
+                        }),
+                    },
+                })
+
+                const inferConfig = createEndpointConfig("/type/:typeId", {
+                    schemas: {
+                        params: valibot.object({
+                            typeId: valibot.enum({ token: "token", code: "code" }),
+                        }),
+                    },
+                })
+
+                const endpoint = createEndpoint(
+                    "GET",
+                    "/signIn/:oauth",
+                    (ctx) => {
+                        const oauth = ctx.params.oauth
+                        return Response.json({ oauth })
+                    },
+                    config
+                )
+
+                const inferEndpoint = createEndpoint(
+                    "GET",
+                    "/type/:typeId",
+                    (ctx) => {
+                        return Response.json({ typeId: ctx.params.typeId })
+                    },
+                    inferConfig
+                )
+
+                const { GET } = createRouter([endpoint, inferEndpoint])
+
+                test("With valid params", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/signIn/google"))
+                    expect(get.ok).toBe(true)
+                    expect(await get.json()).toEqual({ oauth: "google" })
+                })
+
+                test("With invalid params", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/signIn/facebook"))
+                    expect(get.status).toBe(422)
+                    expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
+                    expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
+                })
+
+                test("With inferred params", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/type/token"))
+                    expect(get.ok).toBe(true)
+                    expect(await get.json()).toEqual({ typeId: "token" })
+                })
+
+                test("With invalid inferred params", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/type/invalid"))
+                    expect(get.status).toBe(422)
+                    expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
+                    expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
+                })
             })
 
-            const endpoint = createEndpoint(
-                "GET",
-                "/signIn/:oauth",
-                (ctx) => {
-                    const oauth = ctx.params.oauth
-                    return Response.json({ oauth })
-                },
-                config
-            )
+            describe("Arktype params schema", () => {
+                const config = createEndpointConfig("/signIn/:oauth", {
+                    schemas: {
+                        params: type({
+                            oauth: type.enumerated("google", "github"),
+                        }),
+                    },
+                })
 
-            const inferEndpoint = createEndpoint(
-                "GET",
-                "/type/:typeId",
-                (ctx) => {
-                    return Response.json({ typeId: ctx.params.typeId })
-                },
-                inferConfig
-            )
+                const inferConfig = createEndpointConfig("/type/:typeId", {
+                    schemas: {
+                        params: type({
+                            typeId: type.enumerated("token", "code"),
+                        }),
+                    },
+                })
 
-            const { GET } = createRouter([endpoint, inferEndpoint])
+                const endpoint = createEndpoint(
+                    "GET",
+                    "/signIn/:oauth",
+                    (ctx) => {
+                        const oauth = ctx.params.oauth
+                        return Response.json({ oauth })
+                    },
+                    config
+                )
 
-            test("With valid params", async ({ expect }) => {
-                const get = await GET(new Request("https://example.com/signIn/google"))
-                expect(get.ok).toBe(true)
-                expect(await get.json()).toEqual({ oauth: "google" })
+                const inferEndpoint = createEndpoint(
+                    "GET",
+                    "/type/:typeId",
+                    (ctx) => {
+                        return Response.json({ typeId: ctx.params.typeId })
+                    },
+                    inferConfig
+                )
+
+                const { GET } = createRouter([endpoint, inferEndpoint])
+
+                test("With valid params", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/signIn/google"))
+                    expect(get.ok).toBe(true)
+                    expect(await get.json()).toEqual({ oauth: "google" })
+                })
+
+                test("With invalid params", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/signIn/facebook"))
+                    expect(get.status).toBe(422)
+                    expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
+                    expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
+                })
+
+                test("With inferred params", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/type/token"))
+                    expect(get.ok).toBe(true)
+                    expect(await get.json()).toEqual({ typeId: "token" })
+                })
+
+                test("With invalid inferred params", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/type/invalid"))
+                    expect(get.status).toBe(422)
+                    expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
+                    expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
+                })
             })
 
-            test("With invalid params", async ({ expect }) => {
-                const get = await GET(new Request("https://example.com/signIn/facebook"))
-                expect(get.status).toBe(422)
-                expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
-                expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
-            })
+            describe("Typebox params schema", () => {
+                const config = createEndpointConfig("/signIn/:oauth", {
+                    schemas: {
+                        params: typebox.Object({
+                            oauth: typebox.Enum(["google", "github"]),
+                        }),
+                    },
+                })
 
-            test("With inferred params", async ({ expect }) => {
-                const get = await GET(new Request("https://example.com/type/token"))
-                expect(get.ok).toBe(true)
-                expect(await get.json()).toEqual({ typeId: "token" })
-            })
+                const inferConfig = createEndpointConfig("/type/:typeId", {
+                    schemas: {
+                        params: typebox.Object({
+                            typeId: typebox.Enum(["token", "code"]),
+                        }),
+                    },
+                })
 
-            test("With invalid inferred params", async ({ expect }) => {
-                const get = await GET(new Request("https://example.com/type/invalid"))
-                expect(get.status).toBe(422)
-                expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
-                expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
-            })
-        })
+                const endpoint = createEndpoint(
+                    "GET",
+                    "/signIn/:oauth",
+                    (ctx) => {
+                        const oauth = ctx.params.oauth
+                        return Response.json({ oauth })
+                    },
+                    config
+                )
 
-        describe("Valibot params schema", () => {
-            const config = createEndpointConfig("/signIn/:oauth", {
-                schemas: {
-                    params: valibot.object({
-                        oauth: valibot.enum({ google: "google", github: "github" }),
-                    }),
-                },
-            })
+                const inferEndpoint = createEndpoint(
+                    "GET",
+                    "/type/:typeId",
+                    (ctx) => {
+                        return Response.json({ typeId: ctx.params.typeId })
+                    },
+                    inferConfig
+                )
 
-            const inferConfig = createEndpointConfig("/type/:typeId", {
-                schemas: {
-                    params: valibot.object({
-                        typeId: valibot.enum({ token: "token", code: "code" }),
-                    }),
-                },
-            })
+                const { GET } = createRouter([endpoint, inferEndpoint])
 
-            const endpoint = createEndpoint(
-                "GET",
-                "/signIn/:oauth",
-                (ctx) => {
-                    const oauth = ctx.params.oauth
-                    return Response.json({ oauth })
-                },
-                config
-            )
+                test("With valid params", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/signIn/google"))
+                    expect(get.ok).toBe(true)
+                    expect(await get.json()).toEqual({ oauth: "google" })
+                })
 
-            const inferEndpoint = createEndpoint(
-                "GET",
-                "/type/:typeId",
-                (ctx) => {
-                    return Response.json({ typeId: ctx.params.typeId })
-                },
-                inferConfig
-            )
+                test("With invalid params", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/signIn/facebook"))
+                    expect(get.status).toBe(422)
+                    expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
+                    expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
+                })
 
-            const { GET } = createRouter([endpoint, inferEndpoint])
+                test("With inferred params", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/type/token"))
+                    expect(get.ok).toBe(true)
+                    expect(await get.json()).toEqual({ typeId: "token" })
+                })
 
-            test("With valid params", async ({ expect }) => {
-                const get = await GET(new Request("https://example.com/signIn/google"))
-                expect(get.ok).toBe(true)
-                expect(await get.json()).toEqual({ oauth: "google" })
-            })
-
-            test("With invalid params", async ({ expect }) => {
-                const get = await GET(new Request("https://example.com/signIn/facebook"))
-                expect(get.status).toBe(422)
-                expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
-                expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
-            })
-
-            test("With inferred params", async ({ expect }) => {
-                const get = await GET(new Request("https://example.com/type/token"))
-                expect(get.ok).toBe(true)
-                expect(await get.json()).toEqual({ typeId: "token" })
-            })
-
-            test("With invalid inferred params", async ({ expect }) => {
-                const get = await GET(new Request("https://example.com/type/invalid"))
-                expect(get.status).toBe(422)
-                expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
-                expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
-            })
-        })
-
-        describe("Arktype params schema", () => {
-            const config = createEndpointConfig("/signIn/:oauth", {
-                schemas: {
-                    params: type({
-                        oauth: type.enumerated("google", "github"),
-                    }),
-                },
-            })
-
-            const inferConfig = createEndpointConfig("/type/:typeId", {
-                schemas: {
-                    params: type({
-                        typeId: type.enumerated("token", "code"),
-                    }),
-                },
-            })
-
-            const endpoint = createEndpoint(
-                "GET",
-                "/signIn/:oauth",
-                (ctx) => {
-                    const oauth = ctx.params.oauth
-                    return Response.json({ oauth })
-                },
-                config
-            )
-
-            const inferEndpoint = createEndpoint(
-                "GET",
-                "/type/:typeId",
-                (ctx) => {
-                    return Response.json({ typeId: ctx.params.typeId })
-                },
-                inferConfig
-            )
-
-            const { GET } = createRouter([endpoint, inferEndpoint])
-
-            test("With valid params", async ({ expect }) => {
-                const get = await GET(new Request("https://example.com/signIn/google"))
-                expect(get.ok).toBe(true)
-                expect(await get.json()).toEqual({ oauth: "google" })
-            })
-
-            test("With invalid params", async ({ expect }) => {
-                const get = await GET(new Request("https://example.com/signIn/facebook"))
-                expect(get.status).toBe(422)
-                expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
-                expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
-            })
-
-            test("With inferred params", async ({ expect }) => {
-                const get = await GET(new Request("https://example.com/type/token"))
-                expect(get.ok).toBe(true)
-                expect(await get.json()).toEqual({ typeId: "token" })
-            })
-
-            test("With invalid inferred params", async ({ expect }) => {
-                const get = await GET(new Request("https://example.com/type/invalid"))
-                expect(get.status).toBe(422)
-                expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
-                expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
+                test("With invalid inferred params", async ({ expect }) => {
+                    const get = await GET(new Request("https://example.com/type/invalid"))
+                    expect(get.status).toBe(422)
+                    expect(get.statusText).toBe("UNPROCESSABLE_ENTITY")
+                    expect(await get.json()).toMatchObject({ error: "validation_error", details: {} })
+                })
             })
         })
     })

--- a/test/type.test-d.ts
+++ b/test/type.test-d.ts
@@ -342,22 +342,18 @@ describe("ContextSearchParams", () => {
     describe("Typebox instance", () => {
         expectTypeOf<
             ContextSearchParams<{
-                searchParams: TObject<
-                    {
-                        code: TString
-                    }
-                >
+                searchParams: TObject<{
+                    code: TString
+                }>
             }>
         >().toEqualTypeOf<{ code: string }>()
 
         expectTypeOf<
             ContextSearchParams<{
-                searchParams: TObject<
-                    {
-                        code: TString
-                        state: TString
-                    }
-                >
+                searchParams: TObject<{
+                    code: TString
+                    state: TString
+                }>
             }>
         >().toEqualTypeOf<{ code: string; state: string }>()
     })
@@ -415,22 +411,18 @@ describe("ContextBody", () => {
     describe("Typebox instance", () => {
         expectTypeOf<
             ContextBody<{
-                body: TObject<
-                    {
-                        username: TString
-                        password: TString
-                    }
-                >
+                body: TObject<{
+                    username: TString
+                    password: TString
+                }>
             }>
         >().toEqualTypeOf<{ username: string; password: string }>()
 
         expectTypeOf<
             ContextBody<{
-                body: TObject<
-                    {
-                        oauth: TString
-                    }
-                >
+                body: TObject<{
+                    oauth: TString
+                }>
             }>
         >().toEqualTypeOf<{ oauth: string }>()
     })
@@ -463,9 +455,12 @@ describe("ContextParams", () => {
         expectTypeOf<
             ContextParams<
                 {
-                    params: ObjectSchema<{
-                        oauth: StringSchema<undefined>
-                    }, undefined>
+                    params: ObjectSchema<
+                        {
+                            oauth: StringSchema<undefined>
+                        },
+                        undefined
+                    >
                 },
                 GetRouteParams<RoutePath>
             >
@@ -520,15 +515,18 @@ describe("ContextParams", () => {
         expectTypeOf<
             ContextParams<
                 {
-                    params: ObjectSchema<{
-                        userId: StringSchema<undefined>
-                        itemId: StringSchema<undefined>
-                    }, undefined>
+                    params: ObjectSchema<
+                        {
+                            userId: StringSchema<undefined>
+                            itemId: StringSchema<undefined>
+                        },
+                        undefined
+                    >
                 },
                 GetRouteParams<RoutePath>
             >
         >().toEqualTypeOf<{ userId: string; itemId: string }>()
-         expectTypeOf<
+        expectTypeOf<
             ContextParams<
                 {
                     params: TObject<{
@@ -541,35 +539,32 @@ describe("ContextParams", () => {
         >().toEqualTypeOf<{ userId: string; itemId: string }>()
 
         expectTypeOf<
-            ContextParams<
-                {
-                    params: ZodObject<{
-                        userId: ZodString
-                        itemId: ZodString
-                    }>
-                }
-            >
+            ContextParams<{
+                params: ZodObject<{
+                    userId: ZodString
+                    itemId: ZodString
+                }>
+            }>
         >().toEqualTypeOf<{ userId: string; itemId: string }>()
         expectTypeOf<
-            ContextParams<
-                {
-                    params: ObjectSchema<{
+            ContextParams<{
+                params: ObjectSchema<
+                    {
                         userId: StringSchema<undefined>
                         itemId: StringSchema<undefined>
-                    }, undefined>
-                }
-            >
+                    },
+                    undefined
+                >
+            }>
         >().toEqualTypeOf<{ userId: string; itemId: string }>()
-         expectTypeOf<
-            ContextParams<
-                {
-                    params: TObject<{
-                        userId: TString
-                        itemId: TString
-                    }>
-                }
-            >
-        >().toEqualTypeOf<{ userId: string; itemId: string }>()    
+        expectTypeOf<
+            ContextParams<{
+                params: TObject<{
+                    userId: TString
+                    itemId: TString
+                }>
+            }>
+        >().toEqualTypeOf<{ userId: string; itemId: string }>()
     })
 })
 

--- a/test/type.test-d.ts
+++ b/test/type.test-d.ts
@@ -23,6 +23,7 @@ import type {
 } from "@/@types/index.ts"
 import { ZodEnum, type ZodObject, type ZodString } from "zod"
 import type { EnumSchema, ObjectSchema, StringSchema } from "valibot"
+import type { TObject, TString, TEnum } from "typebox"
 
 type RoutePath = "/auth/:oauth"
 type EmptyObject = Record<PropertyKey, never>
@@ -337,6 +338,29 @@ describe("ContextSearchParams", () => {
             }>
         >().toEqualTypeOf<{ code: string; state: string }>()
     })
+
+    describe("Typebox instance", () => {
+        expectTypeOf<
+            ContextSearchParams<{
+                searchParams: TObject<
+                    {
+                        code: TString
+                    }
+                >
+            }>
+        >().toEqualTypeOf<{ code: string }>()
+
+        expectTypeOf<
+            ContextSearchParams<{
+                searchParams: TObject<
+                    {
+                        code: TString
+                        state: TString
+                    }
+                >
+            }>
+        >().toEqualTypeOf<{ code: string; state: string }>()
+    })
 })
 
 describe("ContextBody", () => {
@@ -387,6 +411,29 @@ describe("ContextBody", () => {
             }>
         >().toEqualTypeOf<{ oauth: string }>()
     })
+
+    describe("Typebox instance", () => {
+        expectTypeOf<
+            ContextBody<{
+                body: TObject<
+                    {
+                        username: TString
+                        password: TString
+                    }
+                >
+            }>
+        >().toEqualTypeOf<{ username: string; password: string }>()
+
+        expectTypeOf<
+            ContextBody<{
+                body: TObject<
+                    {
+                        oauth: TString
+                    }
+                >
+            }>
+        >().toEqualTypeOf<{ oauth: string }>()
+    })
 })
 
 describe("ContextParams", () => {
@@ -413,6 +460,26 @@ describe("ContextParams", () => {
                 GetRouteParams<RoutePath>
             >
         >().toEqualTypeOf<{ oauth: string }>()
+        expectTypeOf<
+            ContextParams<
+                {
+                    params: ObjectSchema<{
+                        oauth: StringSchema<undefined>
+                    }, undefined>
+                },
+                GetRouteParams<RoutePath>
+            >
+        >().toEqualTypeOf<{ oauth: string }>()
+        expectTypeOf<
+            ContextParams<
+                {
+                    params: TObject<{
+                        oauth: TString
+                    }>
+                },
+                GetRouteParams<RoutePath>
+            >
+        >().toEqualTypeOf<{ oauth: string }>()
 
         expectTypeOf<
             ContextParams<{
@@ -421,7 +488,6 @@ describe("ContextParams", () => {
                 }>
             }>
         >().toEqualTypeOf<{ role: "admin" | "user" | "guest" }>()
-
         expectTypeOf<
             ContextParams<{
                 params: ObjectSchema<
@@ -432,6 +498,13 @@ describe("ContextParams", () => {
                 >
             }>
         >().toEqualTypeOf<{ oauth: "admin" | "user" | "guest" }>()
+        expectTypeOf<
+            ContextParams<{
+                params: TObject<{
+                    role: TEnum<["admin", "user", "guest"]>
+                }>
+            }>
+        >().toEqualTypeOf<{ role: "admin" | "user" | "guest" }>()
 
         expectTypeOf<
             ContextParams<
@@ -444,34 +517,59 @@ describe("ContextParams", () => {
                 GetRouteParams<RoutePath>
             >
         >().toEqualTypeOf<{ userId: string; itemId: string }>()
-
         expectTypeOf<
             ContextParams<
                 {
-                    params: ObjectSchema<
-                        {
-                            oauth: StringSchema<undefined>
-                        },
-                        undefined
-                    >
-                },
-                GetRouteParams<RoutePath>
-            >
-        >().toEqualTypeOf<{ oauth: string }>()
-        expectTypeOf<
-            ContextParams<
-                {
-                    params: ObjectSchema<
-                        {
-                            userId: StringSchema<undefined>
-                            itemId: StringSchema<undefined>
-                        },
-                        undefined
-                    >
+                    params: ObjectSchema<{
+                        userId: StringSchema<undefined>
+                        itemId: StringSchema<undefined>
+                    }, undefined>
                 },
                 GetRouteParams<RoutePath>
             >
         >().toEqualTypeOf<{ userId: string; itemId: string }>()
+         expectTypeOf<
+            ContextParams<
+                {
+                    params: TObject<{
+                        userId: TString
+                        itemId: TString
+                    }>
+                },
+                GetRouteParams<RoutePath>
+            >
+        >().toEqualTypeOf<{ userId: string; itemId: string }>()
+
+        expectTypeOf<
+            ContextParams<
+                {
+                    params: ZodObject<{
+                        userId: ZodString
+                        itemId: ZodString
+                    }>
+                }
+            >
+        >().toEqualTypeOf<{ userId: string; itemId: string }>()
+        expectTypeOf<
+            ContextParams<
+                {
+                    params: ObjectSchema<{
+                        userId: StringSchema<undefined>
+                        itemId: StringSchema<undefined>
+                    }, undefined>
+                }
+            >
+        >().toEqualTypeOf<{ userId: string; itemId: string }>()
+         expectTypeOf<
+            ContextParams<
+                {
+                    params: TObject<{
+                        userId: TString
+                        itemId: TString
+                    }>
+                }
+            >
+        >().toEqualTypeOf<{ userId: string; itemId: string }>()    
     })
 })
 


### PR DESCRIPTION
## Description

This pull request adds ArkType schema validation support alongside the existing Zod, Valibot and Arktype integrations.

Aura Router now supports three schema validation libraries for endpoint validation across:
- request body
- route parameters
- search parameters

---

## Changes

- Add Typebox schema validation support
- Extend endpoint schema compatibility to support:
  - Zod
  - Valibot
  - ArkType
  - Typebox
- Preserve type inference across router and client APIs

---


## Usage

```ts
import { Object, String } from "typebox"

import {
  createEndpoint,
  createRouter,
  createClient,
} from "@aura-stack/router"

const credentials = createEndpoint(
  "POST",
  "/auth/credentials",
  (ctx) => {
    return Response.json({
      body: ctx.body,
    })
  },
  {
    schemas: {
      body: Object({
        username: String(),
        password: String(),
      }),
    },
  }
)

const router = createRouter([credentials])

const client = createClient<typeof router>({
  baseURL: "http://api.example.com",
})

await client.post("/auth/credentials", {
  body: {
    username: "johndoe",
    password: "1234567890",
  },
})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended validation to support TypeBox schemas for request bodies, search parameters, and route parameters.
  * TypeBox is now available as an optional peer dependency.

* **Tests**
  * Added comprehensive test coverage for TypeBox schema validation scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aura-stack-ts/router/pull/48)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->