### PR TITLE
feat(types)!: remove TypeBox type inference support

### DIFF
--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -1,5 +1,5 @@
 import type { Type } from "arktype"
-import type { Static, TObject } from "typebox"
+import type { TObject } from "typebox"
 import type { $ZodObject as ZodObject, infer as $Infer } from "zod/v4/core"
 import type { ObjectSchema } from "valibot"
 import type { RouterError } from "@/error.ts"
@@ -76,7 +76,7 @@ export type UnwrapSchema<S, Fallback> = [S] extends [ZodObject<any>]
       : [S] extends [Type<infer T>]
         ? T
         : [S] extends [TObject]
-          ? Static<S>
+          ? S
           : Fallback
 
 /**

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -31,7 +31,7 @@ export const createEndpoint = <
     const Method extends Uppercase<HTTPMethod> | Uppercase<HTTPMethod>[],
     const Route extends RoutePattern,
     Schemas extends EndpointSchemas,
-    Handler extends RouteHandler<Route, Method, { schemas: Schemas }, RouteHandlerReturn>,
+    Handler extends RouteHandler<Route, Method, { schemas?: Schemas }, RouteHandlerReturn>,
 >(
     method: Method,
     route: Route,

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -623,8 +623,9 @@ describe("createEndpoint", () => {
                     "GET",
                     "/signIn/:oauth",
                     (ctx) => {
-                        const oauth = ctx.params.oauth
-                        return Response.json({ oauth })
+                        type Params = typebox.Static<typeof ctx.params>
+                        const params = ctx.params as unknown as Params
+                        return Response.json({ oauth: params.oauth })
                     },
                     config
                 )
@@ -633,7 +634,9 @@ describe("createEndpoint", () => {
                     "GET",
                     "/type/:typeId",
                     (ctx) => {
-                        return Response.json({ typeId: ctx.params.typeId })
+                        type Params = typebox.Static<typeof ctx.params>
+                        const params = ctx.params as unknown as Params
+                        return Response.json({ typeId: params.typeId })
                     },
                     inferConfig
                 )

--- a/test/type.test-d.ts
+++ b/test/type.test-d.ts
@@ -333,7 +333,7 @@ describe("ContextSearchParams", () => {
                     code: TString
                 }>
             }>
-        >().toEqualTypeOf<{ code: string }>()
+        >().toEqualTypeOf<TObject<{ code: TString }>>()
 
         expectTypeOf<
             ContextSearchParams<{
@@ -342,7 +342,7 @@ describe("ContextSearchParams", () => {
                     state: TString
                 }>
             }>
-        >().toEqualTypeOf<{ code: string; state: string }>()
+        >().toEqualTypeOf<TObject<{ code: TString; state: TString }>>()
     })
 })
 
@@ -403,7 +403,7 @@ describe("ContextBody", () => {
                     password: TString
                 }>
             }>
-        >().toEqualTypeOf<{ username: string; password: string }>()
+        >().toEqualTypeOf<TObject<{ username: TString; password: TString }>>()
 
         expectTypeOf<
             ContextBody<{
@@ -411,7 +411,7 @@ describe("ContextBody", () => {
                     oauth: TString
                 }>
             }>
-        >().toEqualTypeOf<{ oauth: string }>()
+        >().toEqualTypeOf<TObject<{ oauth: TString }>>()
     })
 })
 
@@ -461,7 +461,7 @@ describe("ContextParams", () => {
                 },
                 GetRouteParams<RoutePath>
             >
-        >().toEqualTypeOf<{ oauth: string }>()
+        >().toEqualTypeOf<TObject<{ oauth: TString }>>()
 
         expectTypeOf<
             ContextParams<{
@@ -486,7 +486,7 @@ describe("ContextParams", () => {
                     role: TEnum<["admin", "user", "guest"]>
                 }>
             }>
-        >().toEqualTypeOf<{ role: "admin" | "user" | "guest" }>()
+        >().toEqualTypeOf<TObject<{ role: TEnum<["admin", "user", "guest"]> }>>()
 
         expectTypeOf<
             ContextParams<
@@ -523,7 +523,7 @@ describe("ContextParams", () => {
                 },
                 GetRouteParams<RoutePath>
             >
-        >().toEqualTypeOf<{ userId: string; itemId: string }>()
+        >().toEqualTypeOf<TObject<{ userId: TString; itemId: TString }>>()
 
         expectTypeOf<
             ContextParams<{
@@ -551,7 +551,7 @@ describe("ContextParams", () => {
                     itemId: TString
                 }>
             }>
-        >().toEqualTypeOf<{ userId: string; itemId: string }>()
+        >().toEqualTypeOf<TObject<{ userId: TString; itemId: TString }>>()
     })
 })
 

--- a/tsconfig.diag.json
+++ b/tsconfig.diag.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json", // Inherit your base paths and options
-  "compilerOptions": {
-    "noEmit": true,
-    "skipLibCheck": true // CRITICAL: Tells TS not to type-check node_modules/*.d.ts files
-  },
-  "include": ["src/**/*"] // Strictly limit the entry points to your source code
-}


### PR DESCRIPTION
## Description

This pull request removes automatic type inference for TypeBox schemas in endpoint definitions.

The change was introduced after profiling and diagnostics performed in #51 revealed that TypeBox's `Static` utility type introduces significant type-checking overhead and is one of the primary contributors to excessive type instantiations and TypeScript compiler performance degradation.

While automatic type inference has been removed, **runtime validation remains fully supported**. TypeBox schemas can still be used to validate:

* request bodies
* route parameters
* search parameters

without any changes to the runtime behavior of the router.

Consumers who require TypeScript type inference must now define types explicitly or use TypeBox's `Static` utility type directly within their application code.

> [!NOTE]
> This change was prompted by the diagnostics and compiler performance analysis introduced in #51, which identified `Static` as one of the largest sources of type instantiation growth and memory consumption within the type system.

One of the most significant improvements observed after removing automatic TypeBox inference was the reduction in TypeScript type instantiations. According to diagnostics generated using:

```bash
tsc --extendedDiagnostics
```

The number of type instantiations dropped from 1,187,356 to 22,509. This represents a reduction of approximately 98.1%, resulting in substantially lower compiler workload, reduced memory consumption, and improved type-checking performance.


### Key Changes

* Removed automatic type inference for TypeBox schemas
* Preserved full runtime validation support for TypeBox
* Reduced internal type complexity and compiler overhead
* Improved TypeScript performance for projects using TypeBox schemas

### Usage

```ts
import * as typebox from "typebox"
import {
  createEndpoint,
  createEndpointConfig,
} from "@aura-stack/router"

const config = createEndpointConfig("/signIn/:oauth", {
  schemas: {
    params: typebox.Object({
      oauth: typebox.Enum(["google", "github"]),
    }),
  },
})

const endpoint = createEndpoint(
  "GET",
  "/signIn/:oauth",
  (ctx) => {
    type Params = typebox.Static<
      typeof config.schemas.params
    >

    // Automatic inference is no longer provided.
    const params = ctx.params as Params

    return Response.json({
      oauth: params.oauth,
    })
  },
  config
)
```

> [!WARNING]
> BREAKING CHANGE: Automatic type inference from TypeBox schemas has been removed.
>
> TypeBox schemas remain fully supported for runtime validation, but TypeScript type inference is no longer generated automatically by Aura Router.
>
> Consumers must define types explicitly or use TypeBox's `Static` utility type when type inference is required.

## Related PRs

* #51

