### PR TITLE
feat(types)!: remove TypeBox schema type inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Per-package version history is maintained inside each package’s own `CHANGELOG
 
 ## [Unreleased]
 
+### Changed
+
+- Removed TypeBox compile-time type inference for `searchParams`, `params`, and `body` in client functions produced by `createClient`. Runtime validation with TypeBox remains supported, but `Static`-based inference is no longer used for client call signatures. [#54](https://github.com/aura-stack-ts/router/pull/54)
+
+---
+
+## [0.7.1] - 2026-06-04
+
+### Changed
+
+- Removed TypeBox compile-time type inference for `searchParams`, `params`, and `body` in endpoints and middlewares due to the performance cost of `Static` from the `typebox` package. Runtime validation with TypeBox remains supported. [#52](https://github.com/aura-stack-ts/router/pull/52)
+
 ---
 
 ## [0.7.0] - 2026-05-13

--- a/src/@types/client.ts
+++ b/src/@types/client.ts
@@ -10,7 +10,7 @@ export type InferSchema<T, Kind = SchemaKind<T>> = Kind extends "zod"
     : Kind extends "valibot"
       ? InferValibotSchema<T & ObjectSchema<any, undefined>>
       : Kind extends "typebox"
-        ? T
+        ? {}
         : [T] extends [Type<infer U>]
           ? U
           : T

--- a/src/@types/client.ts
+++ b/src/@types/client.ts
@@ -1,6 +1,5 @@
 import type { Type } from "arktype"
 import type { ObjectSchema } from "valibot"
-import type { Static, TSchema } from "typebox"
 import type { RequestHeaders } from "@/@types/http.ts"
 import type { infer as Infer } from "zod/v4/core"
 import type { InferValibotSchema, SchemaKind, SupportedSchema } from "@/@types/schemas.ts"
@@ -11,7 +10,7 @@ export type InferSchema<T, Kind = SchemaKind<T>> = Kind extends "zod"
     : Kind extends "valibot"
       ? InferValibotSchema<T & ObjectSchema<any, undefined>>
       : Kind extends "typebox"
-        ? Static<T & TSchema>
+        ? T
         : [T] extends [Type<infer U>]
           ? U
           : T
@@ -43,6 +42,7 @@ type InferContent<Config extends EndpointConfig<any, any, any>> =
               ? RemoveUndefined<ToInferSchema<Schemas>>
               : unknown
         : unknown
+
 /**
  * Generates a client type based on the provided route endpoints. Each endpoint's method and route are
  * used to create a corresponding function to access the endpoint.

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -538,19 +538,16 @@ test("Client type inference with TypeBox schemas", async () => {
         baseURL: "http://api.example.com",
     })
 
-    // @ts-expect-error invalid typebox support.
     client.get("/items/:itemId", {
         params: {
             itemId: "123",
         },
     })
 
-    // @ts-expect-error invalid typebox support.
     client.get("/items/:itemId", {
         params: { itemId: "123" },
     })
 
-    // @ts-expect-error invalid typebox support.
     const item = await client.get("/items/:itemId", {
         params: { itemId: "123" },
     })
@@ -563,9 +560,7 @@ test("Client type inference with TypeBox schemas", async () => {
     expectTypeOf<typeof newItem>().toEqualTypeOf<JsonResponse<{ method: "POST" }>>()
 
     const deletedItem = await client.delete("/items/:itemId", {
-        // @ts-expect-error invalid typebox support.
         params: { itemId: "123" },
-        // @ts-expect-error invalid typebox support.
         searchParams: { force: "true" },
     })
     expectTypeOf<typeof deletedItem>().toEqualTypeOf<JsonResponse<{ method: "DELETE" }>>()

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -528,22 +528,29 @@ test("Client type inference with TypeBox schemas", async () => {
         }
     )
 
-    const router = createRouter([getItem, createItem, deleteItem])
+    const getItems = createEndpoint("GET", "/items", (ctx) => {
+        return ctx.json({ method: ctx.method })
+    })
+
+    const router = createRouter([getItem, createItem, deleteItem, getItems])
 
     const client = createClient<typeof router>({
         baseURL: "http://api.example.com",
     })
 
+    // @ts-expect-error invalid typebox support.
     client.get("/items/:itemId", {
         params: {
             itemId: "123",
         },
     })
 
+    // @ts-expect-error invalid typebox support.
     client.get("/items/:itemId", {
         params: { itemId: "123" },
     })
 
+    // @ts-expect-error invalid typebox support.
     const item = await client.get("/items/:itemId", {
         params: { itemId: "123" },
     })
@@ -556,7 +563,9 @@ test("Client type inference with TypeBox schemas", async () => {
     expectTypeOf<typeof newItem>().toEqualTypeOf<JsonResponse<{ method: "POST" }>>()
 
     const deletedItem = await client.delete("/items/:itemId", {
+        // @ts-expect-error invalid typebox support.
         params: { itemId: "123" },
+        // @ts-expect-error invalid typebox support.
         searchParams: { force: "true" },
     })
     expectTypeOf<typeof deletedItem>().toEqualTypeOf<JsonResponse<{ method: "DELETE" }>>()


### PR DESCRIPTION

## Description

This pull request removes TypeBox-based type inference for the `searchParams`, `params`, and `body` fields from the client functions returned by `createClient`.

Previously, these types were inferred using TypeBox's `Static` type. However, `Static` introduces a significant amount of type-level computation and has proven to be extremely expensive for TypeScript performance. To reduce the number of type instantiations and improve compile-time performance, this PR removes the use of `Static` from the client implementation while preserving runtime schema validation.

The client type system still infers whether `searchParams`, `params`, or `body` are required for a given endpoint. However, it no longer infers the individual fields within those objects.

---

In #52, TypeBox-based inference for `searchParams`, `params`, and `body` was removed from middleware and handler contexts based on the diagnostics performed in that pull request. However, during the investigation in aura-stack-ts/auth#179, it was discovered that `client.ts` was still responsible for a large number of expensive type operations due to the remaining usage of TypeBox's `Static` type.

### Diagnostic Results

The following results show the number of TypeScript instantiations after the changes introduced by this PR:

* **22,388** — `src` only
* **44,349** — `src` and `bench`
* **167,707** — `src`, `bench`, and `test`

## Usage

```ts
const getItem = createEndpoint(
  "GET",
  "/items/:itemId",
  (ctx) => {
    return ctx.json({ method: ctx.method })
  },
  {
    schemas: {
      params: typebox.Object({
        itemId: typebox.String(),
      }),
    },
  }
)

const router = createRouter([getItem])

const client = createClient<typeof router>({
  baseURL: "http://api.example.com",
})

client.get("/items/:itemId", {
  // Infers that params is required,
  // but does not infer the fields inside the object.
  params: {
    itemId: "123",
  },
})
```

## Related PRs

* #52
* #51