### PR TITLE
chore(release): bump package version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Per-package version history is maintained inside each package’s own `CHANGELOG
 
 ## [Unreleased]
 
+---
+
+## [0.7.2] - 2026-06-05
+
 ### Changed
 
 - Removed TypeBox compile-time type inference for `searchParams`, `params`, and `body` in client functions produced by `createClient`. Runtime validation with TypeBox remains supported, but `Static`-based inference is no longer used for client call signatures. [#54](https://github.com/aura-stack-ts/router/pull/54)

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/router",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "tasks": {
     "dev": "deno run --watch src/index.ts"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/router",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": false,
   "type": "module",
   "description": "A lightweight TypeScript library for building, managing, and validating API routes and endpoints in Node.js applications.",


### PR DESCRIPTION
## Description

This pull request bumps the package version to `v0.7.1`. This release focuses on improving TypeScript compiler performance and reducing type-system complexity within `@aura-stack/router/client`. The work was primarily driven by performance issues identified during the investigation of TypeBox integration, where the `Static` utility type was found to dramatically increase type instantiations and compiler workload.

As part of these improvements, automatic type inference from TypeBox schemas has been removed. This change significantly reduces type-checking overhead while preserving full runtime validation support.

According to diagnostics generated with:

```bash
tsc --extendedDiagnostics
```

type instantiations were reduced from 1,187,356 to 22,509 representing an approximate 98.1% reduction in type instantiations.

> [!WARNING]
> BREAKING CHANGE: Automatic type inference from TypeBox schemas has been removed.
>
> TypeBox schemas remain fully supported for runtime validation, but TypeScript type inference is no longer generated automatically by Aura Router.
>
> Consumers must define types explicitly or use TypeBox's `Static` utility type when type inference is required.

### Related PRs
- #54  

## Resources

- [npm package](https://www.npmjs.com/package/@aura-stack/router)
- [JSR package](https://jsr.io/@aura-stack/router)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Removed compile-time type inference for `searchParams`, `params`, and `body` in client functions; runtime validation remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->