### PR TITLE
fix(endpoint): fix generic inference in `createEndpointConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Per-package version history is maintained inside each package’s own `CHANGELOG
 
 - Added a hooks system for managing the request lifecycle, enabling custom logic to run at different stages of request processing. Supported hooks include `onRequest`, `onMatch`, `onParams`, `onSearchParams`, `onBody`, `onHandler`, `onResponse`, and `onError`. [`#56`](https://github.com/aura-stack-ts/router/pull/56)
 
+### Fixed
+
+- Fixed type inference in `createEndpointConfig()` when defining endpoint schemas. The endpoint configuration is now inferred correctly, allowing schemas, hooks, and middlewares to be typed automatically without manually specifying route or schema types. [#57](https://github.com/aura-stack-ts/router/pull/57)
+
 ---
 
 ## [0.7.2] - 2026-06-05

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -83,14 +83,14 @@ export const createEndpoint = <
  *   return new Response("User details");
  * }, config);
  */
-export function createEndpointConfig<Schemas extends EndpointSchemas>(
-    config: EndpointConfig<RoutePattern, HTTPMethod | HTTPMethod[], Schemas>
-): EndpointConfig<RoutePattern, HTTPMethod | HTTPMethod[], Schemas>
+export function createEndpointConfig<
+    Route extends RoutePattern,
+    Config extends EndpointConfig<Route, HTTPMethod | HTTPMethod[], EndpointSchemas>,
+>(route: Route, config: Config): Config
 
-export function createEndpointConfig<Route extends RoutePattern, Schemas extends EndpointSchemas>(
-    route: Route,
-    config: EndpointConfig<Route, HTTPMethod | HTTPMethod[], Schemas>
-): EndpointConfig<Route, HTTPMethod | HTTPMethod[], Schemas>
+export function createEndpointConfig<Config extends EndpointConfig<RoutePattern, HTTPMethod | HTTPMethod[], EndpointSchemas>>(
+    config: Config
+): Config
 
 export function createEndpointConfig(...args: unknown[]) {
     if (typeof args[0] === "string") return args[1]

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -4,7 +4,7 @@ import { z } from "zod"
 import * as valibot from "valibot"
 import * as typebox from "typebox"
 import { createRouter } from "@/router.ts"
-import { createEndpoint } from "@/endpoint.ts"
+import { createEndpoint, createEndpointConfig } from "@/endpoint.ts"
 import { createClient } from "@/client.ts"
 import type { JsonResponse } from "@/@types/index.ts"
 
@@ -287,21 +287,30 @@ describe("Client", () => {
 })
 
 test("Client type inference with Zod schemas", async () => {
+    const getItemConfig = createEndpointConfig({
+        schemas: {
+            params: z.object({ itemId: z.string() }),
+        },
+    })
+
     const getItem = createEndpoint(
         "GET",
         "/items/:itemId",
         (ctx) => {
             return ctx.json({ method: ctx.method })
         },
-        {
-            schemas: {
-                params: z.object({ itemId: z.string() }),
-            },
-        }
+        getItemConfig
     )
 
     const createItem = createEndpoint("POST", "/items", (ctx) => {
         return ctx.json({ method: ctx.method })
+    })
+
+    const deleteItemConfig = createEndpointConfig({
+        schemas: {
+            params: z.object({ itemId: z.string() }),
+            searchParams: z.object({ force: z.string().optional() }),
+        },
     })
 
     const deleteItem = createEndpoint(
@@ -310,12 +319,7 @@ test("Client type inference with Zod schemas", async () => {
         (ctx) => {
             return ctx.json({ method: ctx.method })
         },
-        {
-            schemas: {
-                params: z.object({ itemId: z.string() }),
-                searchParams: z.object({ force: z.string().optional() }),
-            },
-        }
+        deleteItemConfig
     )
 
     const router = createRouter([getItem, createItem, deleteItem])
@@ -347,21 +351,30 @@ test("Client type inference with Zod schemas", async () => {
 })
 
 test("Client type inference with Valibot schemas", async () => {
+    const getItemConfig = createEndpointConfig({
+        schemas: {
+            params: valibot.object({ itemId: valibot.string() }),
+        },
+    })
+
     const getItem = createEndpoint(
         "GET",
         "/items/:itemId",
         (ctx) => {
             return ctx.json({ method: ctx.method })
         },
-        {
-            schemas: {
-                params: valibot.object({ itemId: valibot.string() }),
-            },
-        }
+        getItemConfig
     )
 
     const createItem = createEndpoint("POST", "/items", (ctx) => {
         return ctx.json({ method: ctx.method })
+    })
+
+    const deleteItemConfig = createEndpointConfig({
+        schemas: {
+            params: valibot.object({ itemId: valibot.string() }),
+            searchParams: valibot.object({ force: valibot.string() }),
+        },
     })
 
     const deleteItem = createEndpoint(
@@ -370,12 +383,7 @@ test("Client type inference with Valibot schemas", async () => {
         (ctx) => {
             return ctx.json({ method: ctx.method })
         },
-        {
-            schemas: {
-                params: valibot.object({ itemId: valibot.string() }),
-                searchParams: valibot.object({ force: valibot.string() }),
-            },
-        }
+        deleteItemConfig
     )
 
     const router = createRouter([getItem, createItem, deleteItem])
@@ -413,23 +421,36 @@ test("Client type inference with Valibot schemas", async () => {
 })
 
 test("Client type inference with Arktype schemas", async () => {
+    const getItemConfig = createEndpointConfig({
+        schemas: {
+            params: type({
+                itemId: "string",
+            }),
+        },
+    })
+
     const getItem = createEndpoint(
         "GET",
         "/items/:itemId",
         (ctx) => {
             return ctx.json({ method: ctx.method })
         },
-        {
-            schemas: {
-                params: type({
-                    itemId: "string",
-                }),
-            },
-        }
+        getItemConfig
     )
 
     const createItem = createEndpoint("POST", "/items", (ctx) => {
         return ctx.json({ method: ctx.method })
+    })
+
+    const deleteItemConfig = createEndpointConfig({
+        schemas: {
+            params: type({
+                itemId: "string",
+            }),
+            searchParams: type({
+                force: "string",
+            }),
+        },
     })
 
     const deleteItem = createEndpoint(
@@ -438,16 +459,7 @@ test("Client type inference with Arktype schemas", async () => {
         (ctx) => {
             return ctx.json({ method: ctx.method })
         },
-        {
-            schemas: {
-                params: type({
-                    itemId: "string",
-                }),
-                searchParams: type({
-                    force: "string",
-                }),
-            },
-        }
+        deleteItemConfig
     )
 
     const router = createRouter([getItem, createItem, deleteItem])
@@ -491,23 +503,36 @@ test("Client type inference with Arktype schemas", async () => {
 })
 
 test("Client type inference with TypeBox schemas", async () => {
+    const getItemConfig = createEndpointConfig({
+        schemas: {
+            params: typebox.Object({
+                itemId: typebox.String(),
+            }),
+        },
+    })
+
     const getItem = createEndpoint(
         "GET",
         "/items/:itemId",
         (ctx) => {
             return ctx.json({ method: ctx.method })
         },
-        {
-            schemas: {
-                params: typebox.Object({
-                    itemId: typebox.String(),
-                }),
-            },
-        }
+        getItemConfig
     )
 
     const createItem = createEndpoint("POST", "/items", (ctx) => {
         return ctx.json({ method: ctx.method })
+    })
+
+    const deleteItemConfig = createEndpointConfig({
+        schemas: {
+            params: typebox.Object({
+                itemId: typebox.String(),
+            }),
+            searchParams: typebox.Object({
+                force: typebox.String(),
+            }),
+        },
     })
 
     const deleteItem = createEndpoint(
@@ -516,16 +541,7 @@ test("Client type inference with TypeBox schemas", async () => {
         (ctx) => {
             return ctx.json({ method: ctx.method })
         },
-        {
-            schemas: {
-                params: typebox.Object({
-                    itemId: typebox.String(),
-                }),
-                searchParams: typebox.Object({
-                    force: typebox.String(),
-                }),
-            },
-        }
+        deleteItemConfig
     )
 
     const getItems = createEndpoint("GET", "/items", (ctx) => {


### PR DESCRIPTION
## Description

This pull request fixes type inference for endpoint configurations.

Previously, endpoint configurations created with `createEndpointConfig` required manually specifying generic parameters in certain scenarios to preserve the correct route, schema, middleware, and hook types. When those generic parameters were omitted, TypeScript fell back to the default values, causing incorrect inference throughout the endpoint definition.

This issue also affected client inference. Since the endpoint configuration lost information about the route and HTTP method, the generated client incorrectly exposed all HTTP methods for a route, even when only a single method was registered.

With this change, endpoint configurations now automatically infer and preserve their complete type information, including:

* Schemas
* Hooks
* Middlewares
* Route definitions
* HTTP methods

As a result, the generated client correctly exposes only the methods that are actually registered for each route.

### Previous Behavior

```ts
const getItemConfig = createEndpointConfig({
  schemas: {
    params: valibot.object({
      itemId: valibot.string(),
    }),
  },
})

const getItem = createEndpoint(
  "GET",
  "/items/:itemId",
  (ctx) => {
    return ctx.json({ method: ctx.method })
  },
  getItemConfig
)

const router = createRouter([getItem])

const client = createClient<typeof router>({
  baseURL: "http://api.example.com",
})

// Correctly inferred
client.get("/items/:itemId", {
  params: {
    itemId: "123",
  },
})

// Incorrectly allowed because the endpoint
// configuration lost route and method information
client.post("/items/:itemId", {
  params: {
    itemId: "123",
  },
})
```

### New Behavior

The complete endpoint configuration is now preserved and inferred automatically. As a result:

* Route information is retained.
* Schema types are preserved.
* Hook and middleware types are preserved.
* Client inference correctly reflects registered endpoints.
* Invalid HTTP methods are no longer exposed for a route.

In the example above, `client.post("/items/:itemId")` is no longer available because only a `GET` endpoint is registered.
