### PR TITLE
feat(validator): export `createValidator` from /validator entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Per-package version history is maintained inside each package’s own `CHANGELOG
 
 ### Added
 
+- Added a public `createValidator()` utility for validating values against Zod, Valibot, TypeBox, and ArkType schemas. The utility is exposed through the `/validator` entry point. [#58](https://github.com/aura-stack-ts/router/pull/58)
+
 - Added a hooks system for managing the request lifecycle, enabling custom logic to run at different stages of request processing. Supported hooks include `onRequest`, `onMatch`, `onParams`, `onSearchParams`, `onBody`, `onHandler`, `onResponse`, and `onError`. [`#56`](https://github.com/aura-stack-ts/router/pull/56)
 
 ### Fixed

--- a/deno.json
+++ b/deno.json
@@ -12,6 +12,7 @@
     "./headers": "./src/headers.ts",
     "./cookie": "./src/cookie.ts",
     "./client": "./src/client.ts",
+    "./validator": "./src/validator/registry.ts",
     "./types": "./src/@types/index.ts"
   },
   "imports": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "type-check": "tsc --noEmit",
     "clean": "rm -rf dist",
     "clean:cts": "rm -rf dist/*.cts",
-    "prepublish": "pnpm clean:cts"
+    "prepublishOnly": "pnpm clean:cts"
   },
   "repository": {
     "type": "git",
@@ -81,6 +81,11 @@
       "types": "./dist/client.d.ts",
       "import": "./dist/client.js",
       "require": "./dist/client.cjs"
+    },
+    "./validator": {
+      "types": "./dist/validator/registry.d.ts",
+      "import": "./dist/validator/registry.js",
+      "require": "./dist/validator/registry.cjs"
     },
     "./types": {
       "types": "./dist/@types/index.d.ts"

--- a/src/@types/client.ts
+++ b/src/@types/client.ts
@@ -2,7 +2,7 @@ import type { Type } from "arktype"
 import type { ObjectSchema } from "valibot"
 import type { RequestHeaders } from "@/@types/http.ts"
 import type { infer as Infer } from "zod/v4/core"
-import type { InferValibotSchema, SchemaKind, SupportedSchema } from "@/@types/schemas.ts"
+import type { InferValibotSchema, SchemaKind, SupportedSchemas } from "@/@types/schemas.ts"
 import type { RoutePattern, EndpointConfig, Prettify, RouteEndpoint, Awaitable } from "@/@types/types.ts"
 
 export type InferSchema<T, Kind = SchemaKind<T>> = Kind extends "zod"
@@ -29,7 +29,7 @@ type HasSchemas<C> =
     C extends EndpointConfig<any, any, infer Schemas>
         ? [SchemaValues<Schemas>] extends [never]
             ? false
-            : [SchemaValues<Schemas>] extends [SupportedSchema]
+            : [SchemaValues<Schemas>] extends [SupportedSchemas]
               ? true
               : false
         : false
@@ -38,7 +38,7 @@ type InferContent<Config extends EndpointConfig<any, any, any>> =
     Config extends EndpointConfig<any, any, infer Schemas>
         ? [SchemaValues<Schemas>] extends [never]
             ? unknown
-            : [SchemaValues<Schemas>] extends [SupportedSchema]
+            : [SchemaValues<Schemas>] extends [SupportedSchemas]
               ? RemoveUndefined<ToInferSchema<Schemas>>
               : unknown
         : unknown

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -1,3 +1,4 @@
 export type * from "@/@types/client.ts"
 export type * from "@/@types/http.ts"
 export type * from "@/@types/types.ts"
+export type * from "@/@types/schemas.ts"

--- a/src/@types/schemas.ts
+++ b/src/@types/schemas.ts
@@ -11,7 +11,7 @@ import type { $ZodType, $ZodObject } from "zod/v4/core"
  */
 export type InferValibotSchema<S extends ObjectSchema<any, undefined>> = NonNullable<S["~types"]>["output"]
 
-export type SupportedSchema = $ZodObject<any> | ObjectSchema<any, undefined> | Type<{}> | TObject<{}>
+export type SupportedSchemas = $ZodObject<any> | ObjectSchema<any, undefined> | Type<{}> | TObject<{}>
 
 /**
  * Infer the schema kind (Zod, Valibot, TypeBox, Arktype) based on the provided schema type.

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -5,7 +5,7 @@ import type { ObjectSchema } from "valibot"
 import type { RouterError } from "@/error.ts"
 import type { HeadersBuilder } from "@/headers.ts"
 import type { HTTPMethod } from "@/@types/http.ts"
-import type { InferValibotSchema, SupportedSchema } from "@/@types/schemas.ts"
+import type { InferValibotSchema, SupportedSchemas } from "@/@types/schemas.ts"
 
 /**
  * Utility type that represents a value that can be either synchronous or a Promise.
@@ -50,9 +50,9 @@ export type GetRouteParams<Route extends RoutePattern> = Route extends `/${infer
  * Available schemas validation for an endpoint. It can include body and searchParams schemas.
  */
 export interface EndpointSchemas {
-    body?: SupportedSchema
-    searchParams?: SupportedSchema
-    params?: SupportedSchema
+    body?: SupportedSchemas
+    searchParams?: SupportedSchemas
+    params?: SupportedSchemas
 }
 
 /**

--- a/src/validator/registry.ts
+++ b/src/validator/registry.ts
@@ -1,7 +1,7 @@
 import { safeParse } from "valibot"
 import { isValibotSchema, isZodSchema, isArkType } from "@/assert.ts"
 import { IsObject } from "typebox"
-import { Check } from "typebox/value"
+import Value, { Check } from "typebox/value"
 
 export type ValidationResult<T> = { success: true; data: T; error: null } | { success: false; data: null; error: any }
 
@@ -33,21 +33,20 @@ export const createValidator = <T>(schema: any): SchemaAdapter<T> => {
                 }
                 if (isArkType(schema)) {
                     const parsed = schema(data)
-                    const isError =
-                        parsed !== null &&
-                        typeof parsed === "object" &&
-                        "summary" in parsed &&
-                        typeof (parsed as any).summary === "string"
-
+                    const isError = !schema.allows(data)
                     return isError
                         ? { success: false, data: null, error: parsed }
                         : { success: true, data: parsed as T, error: null }
                 }
                 if (IsObject(schema)) {
-                    const isValid = Check(schema, data)
+                    let dataToValidate = data
+                    if ((schema as any).strip) {
+                        dataToValidate = Value.Clean(schema, Value.Clone(data))
+                    }
+                    const isValid = Value.Check(schema, dataToValidate)
                     return isValid
-                        ? { success: true, data: data as T, error: null }
-                        : { success: false, data: null, error: new Error("Validation failed") }
+                        ? { success: true, data: dataToValidate as T, error: null }
+                        : { success: false, data: null, error: [...Value.Errors(schema, dataToValidate)] }
                 }
                 return { success: false, data: null, error: new Error("Unsupported schema type") }
             } catch (e) {

--- a/src/validator/registry.ts
+++ b/src/validator/registry.ts
@@ -1,7 +1,7 @@
 import { safeParse } from "valibot"
 import { isValibotSchema, isZodSchema, isArkType } from "@/assert.ts"
 import { IsObject } from "typebox"
-import Value, { Check } from "typebox/value"
+import { Value } from "typebox/value"
 
 export type ValidationResult<T> = { success: true; data: T; error: null } | { success: false; data: null; error: any }
 

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
         "src/cookie.ts",
         "src/client.ts",
         "src/@types/index.ts",
+        "src/validator/registry.ts",
     ],
     format: ["esm", "cjs"],
     dts: true,


### PR DESCRIPTION
## Description

This pull request exports the `createValidator` function through the `/validator` entry point.

The primary motivation for this change is to allow packages built on top of `@aura-stack/router`, such as `@aura-stack/auth`, to reuse the router's built-in validation system instead of maintaining duplicate validation implementations.

By exposing `createValidator`, downstream packages can leverage the same validation logic used internally by Aura Router, ensuring consistent behavior across the ecosystem while reducing code duplication and maintenance overhead.

The exported validator supports all schema libraries currently supported by `@aura-stack/router`:

* Zod
* Valibot
* TypeBox
* ArkType

### Benefits

* Exposes the router's native validation system
* Reduces validation logic duplication across packages
* Promotes consistency between Aura Stack packages
* Simplifies implementation of packages built on top of `@aura-stack/router`
* Supports all officially supported schema providers
